### PR TITLE
Add Queue Job button at the top

### DIFF
--- a/Server/bkr/server/templates/job_form.kid
+++ b/Server/bkr/server/templates/job_form.kid
@@ -24,6 +24,10 @@
         />
     </div>
     <table border="0" cellspacing="0" cellpadding="2">
+        <tr>
+            <td>&#160;</td>
+            <td py:content="submit.display(submit_text)" />
+        </tr>
         <tr py:for="i, field in enumerate(fields)" class="${i%2 and 'odd' or 'even'}">
             <th>
                 <label class="fieldlabel" for="${field.field_id}" py:content="field.label" />


### PR DESCRIPTION
When cloning a job this adds the Queue button at the top as well. My laptop has a wide screen but smaller height hance I have to scroll down every single time to click on this button. 

Patch is totally untested but should work without any issues.
