### PR TITLE
Added liveimg support to kickstart templates

### DIFF
--- a/Server/bkr/server/kickstarts/default
+++ b/Server/bkr/server/kickstarts/default
@@ -4,7 +4,9 @@
 {% snippet snippet_profile %}
 {% endfor  %}
 {% else %}
+{% if liveimg_rpm is undefined and liveimg_file is undefined %}
 {% snippet 'install_method' %}
+{% endif %}
 
 {% if manual is defined %}
 ignoredisk --interactive
@@ -24,7 +26,7 @@ bootloader --location={{ boot_loc|default("mbr") }}{% if kernel_options_post %} 
 repo --name=fedora-updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f{{ distro.osversion.osmajor.number }}&arch={{ distro_tree.arch.arch }}
 {% endif %}
 {% endif %}
-{% if has_rpmostree is not defined %}
+{% if has_rpmostree is undefined and liveimg_rpm is undefined and liveimg_file is undefined %}
 {% snippet 'print_anaconda_repos' %}
 {% endif %}
 
@@ -69,7 +71,14 @@ install
 unsupported_hardware
 {% endif %}
 
-{% if has_rpmostree is not defined %}
+{% if has_rpmostree is defined %}
+ostreesetup --osname=atomic-host --remote=atomic-host --url={{ ostree_repo_url }} --ref={{ ostree_ref }} --nogpg
+{% elif liveimg_rpm is defined %}
+liveimg --url=file:///tmp/squashfs
+{% elif liveimg_file is defined %}
+{% set main_url=distro_tree.url_in_lab(lab_controller, scheme='http', required=True) %}
+liveimg --url={{ main_url }}/{{ liveimg_file }}
+{% else %}
 %packages {{ pkgoptions|default('--ignoremissing') }}
 {%- if not recipe and packages is undefined %} --default
 {% else %}
@@ -81,8 +90,6 @@ unsupported_hardware
 chrony
 {% endif %}
 %end
-{% else %}
-ostreesetup --osname=atomic-host --remote=atomic-host --url={{ ostree_repo_url }} --ref={{ ostree_ref }} --nogpg
 {% endif %}
 
 {% endif %}{# manual #}
@@ -94,6 +101,7 @@ ostreesetup --osname=atomic-host --remote=atomic-host --url={{ ostree_repo_url }
 {% snippet (distro.osversion.osmajor.osmajor + '_pre') %}
 {% snippet (distro.osversion.osmajor.name + '_pre') %}
 {% snippet 'system_pre' %}
+{% snippet 'liveimg_pre' %}
 %end
 
 %post --log=/dev/console
@@ -101,6 +109,7 @@ ostreesetup --osname=atomic-host --remote=atomic-host --url={{ ostree_repo_url }
 {% snippet (distro.osversion.osmajor.osmajor + '_post') %}
 {% snippet (distro.osversion.osmajor.name + '_post') %}
 {% snippet 'system_post' %}
+{% snippet 'liveimg_post' %}
 %end
 
 {{ ks_appends|join('\n') }}

--- a/Server/bkr/server/snippets/liveimg_post
+++ b/Server/bkr/server/snippets/liveimg_post
@@ -1,0 +1,3 @@
+{% if liveimg_post is defined %}
+{{ liveimg_post }}
+{% endif %}

--- a/Server/bkr/server/snippets/liveimg_pre
+++ b/Server/bkr/server/snippets/liveimg_pre
@@ -1,0 +1,7 @@
+{% if liveimg_rpm is defined %}
+cd /tmp
+{% set main_url = distro_tree.url_in_lab(lab_controller, scheme='http', required=True) %}
+fetch - {{ main_url }}/{{ liveimg_rpm }} | rpm2cpio - | cpio -divu
+squashfs=$(find|grep squashfs|grep -v meta)
+ln -s $squashfs /tmp/squashfs
+{% endif %}


### PR DESCRIPTION
Anaconda installs some OSs directly from an image (tarball or squashfs)
that is packed inside the ISO or compose, using the `liveimg` directive.

This patch presents two ways to install from a liveimg, one from a
direct image file and the other from an rpm that contains an image.

The following metadata variables were added to the kickstart templates:

liveimg_file - a relative path to the image itself
liveimg_rpm - a relative path to an rpm that ships an image
liveimg_post - additional line(s) to add to the %post section (usually
post processing is needed after installing with a liveimg)

Signed-off-by: Yuval Turgeman <yturgema@redhat.com>