### PR TITLE
docs: release notes 27.4

### DIFF
--- a/Client/src/bkr/client/commands/cmd_task_delete.py
+++ b/Client/src/bkr/client/commands/cmd_task_delete.py
@@ -9,7 +9,7 @@
 .. _bkr-task-delete:
 
 bkr task-delete: Delete tasks to Beaker's task library
-===================================================
+======================================================
 
 .. program:: bkr task-delete
 

--- a/documentation/whats-new/release-27.rst
+++ b/documentation/whats-new/release-27.rst
@@ -228,3 +228,21 @@ Beaker 27.3
     of beaker-proxy is capable of closing all sockets imminently after
     request is finished.
   | (Contributed by Martin Styk)
+
+Beaker 27.4
+~~~~~~~~~~~
+* | :issue:`1816102`: New command for beaker-client introduced.
+    Beaker-client is providing the way how to remove a task from task
+    library based on the name. This feature is limited to administrators.
+    You can execute as following `bkr task-remove <name>`.
+  | (Contributed by Martin Styk)
+* | :issue:`1795917`:  Added support to use different variable for kickstart
+    on kernel cmdline. Now user can define new `ks_meta` with name
+    `ks_keyword`.
+  | (Contributed by John Villalovos)
+* | :issue:`1818070`: Now, distribution RHVH is imported by default with
+    additional `ks_meta` variable `ks_keyword='inst.ks'`. This mitigates
+    problems with an older version of RHVH where `ks` do not trigger
+    the installation process in RHVH, instead of that, it is considered
+    an upgrade.
+  | (Contributed by Martin Styk)


### PR DESCRIPTION
We covered everything in Beaker for now.
It would be nice to ship new release to upstream.

We have 2 RFEs covered and 1 issue.
- Users can use new ks_meta called ks_keyword which allows users to change kickstart variable on kernel cmdline.
- New command to erase task from Beaker's task library
- Fix for corrupted installation in RHVH.

Signed-off-by: Martin Styk <mastyk@redhat.com>