### PR TITLE
Add multi-console log support

### DIFF
--- a/LabController/labcontroller.conf
+++ b/LabController/labcontroller.conf
@@ -41,3 +41,16 @@ TFTP_ROOT = "/var/lib/tftpboot"
 # Defaults to socket.gethostname(). Ordinarily that is sufficient, unless you
 # have registered this lab controller with Beaker under a CNAME.
 #URL_DOMAIN = "localhost.invalid"
+
+# Location where the console logs are stored. Beaker will look in that
+# directory for files that start with the Fully Qualified Domain Name (FQDN) of
+# the system.
+#   For example:
+#      If CONSOLE_LOGS=/var/consoles/ and the FQDN=test.example.com
+#
+#      Then the following files will be logged as console files:
+#        /var/consoles/test.example.com -> console.log
+#        /var/consoles/test.example.com-bmc -> console-bmc.log
+#        /var/consoles/test.example.com-serial2 -> console-serial2.log
+#
+#CONSOLE_LOGS = "/var/consoles"

--- a/LabController/src/bkr/labcontroller/provision.py
+++ b/LabController/src/bkr/labcontroller/provision.py
@@ -25,6 +25,7 @@ from bkr.common.helpers import SensitiveUnicode, total_seconds
 from bkr.labcontroller.config import load_conf, get_conf
 from bkr.labcontroller.proxy import ProxyHelper
 from bkr.labcontroller import netboot
+import utils
 
 logger = logging.getLogger(__name__)
 
@@ -205,7 +206,12 @@ def build_power_env(command):
     return env
 
 def handle_clear_logs(conf, command):
-    console_log = os.path.join(conf['CONSOLE_LOGS'], command['fqdn'])
+    for filename, _ in utils.get_console_files(
+            console_logs_directory=conf['CONSOLE_LOGS'], system_name=command['fqdn']):
+        truncate_logfile(filename)
+
+
+def truncate_logfile(console_log):
     logger.debug('Truncating console log %s', console_log)
     try:
         f = open(console_log, 'r+')
@@ -214,6 +220,7 @@ def handle_clear_logs(conf, command):
             raise
     else:
         f.truncate()
+
 
 def handle_configure_netboot(command):
     netboot.configure_all(command['fqdn'],

--- a/LabController/src/bkr/labcontroller/utils.py
+++ b/LabController/src/bkr/labcontroller/utils.py
@@ -4,6 +4,7 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
+import os
 import subprocess
 import logging
 from bkr.labcontroller.config import get_conf
@@ -55,3 +56,34 @@ def check_output(*popenargs, **kwargs):
         raise CalledProcessError(retcode, cmd, output=output)
     return output
 
+
+def get_console_files(console_logs_directory, system_name):
+    """Return a list of the console log files for a system
+
+    Given a path to the console_logs_directory and the FQDN (Fully Qualified
+    Domain Name) of the system. Search the console_logs_directory and return a
+    list containing tuples of the full path name to the log file and the name
+    to use when uploading the logfile for log files that are for system_name.
+
+    :param console_logs_directory: Path to the console logs directory
+    :param system_name: Fully qualified domain name of the system
+    :return: List[Tuple[absolute path to log file, name to use for log file]]
+    """
+    if not os.path.isdir(console_logs_directory):
+        logger.info("Console files directory does not exist: %s",
+                    console_logs_directory)
+        return []
+
+    output = []
+    for filename in sorted(os.listdir(console_logs_directory)):
+        if filename.startswith(system_name):
+            full_path = os.path.join(console_logs_directory, filename)
+            if filename == system_name:
+                logfile_name = "console.log"
+            else:
+                description = filename[len(system_name):]
+                # Remove leading hyphens
+                description = description.lstrip('-')
+                logfile_name = "console-{}.log".format(description)
+            output.append((full_path, logfile_name))
+    return output


### PR DESCRIPTION
Support console files with the name of $CONSOLE_LOGS/$FQDN*

For example:
  If CONSOLE_LOGS=/var/consoles and the FQDN=test.example.com

  Then the following files will be logged as console files:
    /var/consoles/test.example.com -> console.log
    /var/consoles/test.example.com-bmc -> console-bmc.log
    /var/consoles/test.example.com-serial2 -> console-serial2.log

Bug: 1771666