### PR TITLE
Make the installation error detection more reliable

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/AtomicHost-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/AtomicHost-defaults.expected
@@ -401,6 +401,42 @@ END
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained-custom.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained-custom.expected
@@ -386,6 +386,42 @@ END
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained.expected
@@ -420,6 +420,42 @@ END
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-scheduler-defaults.expected
@@ -388,6 +388,42 @@ END
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedorarawhide-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedorarawhide-scheduler-defaults.expected
@@ -358,6 +358,42 @@ END
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RHVH-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RHVH-defaults.expected
@@ -370,6 +370,42 @@ imgbase layout --init
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-defaults.expected
@@ -419,6 +419,42 @@ END
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-manual.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-manual.expected
@@ -373,6 +373,42 @@ END
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxAlternateArchitectures7-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxAlternateArchitectures7-scheduler-defaults.expected
@@ -419,6 +419,42 @@ END
 # no snippet data for system_post
 %end
 
+%onerror
+set -x
+# Some distros have curl in their minimal install set, others have wget.
+# We define a wrapper function around the best available implementation
+# so that the rest of the script can use that for making HTTP requests.
+if command -v curl >/dev/null ; then
+    # Older curl versions lack --retry
+    if curl --help 2>&1 | grep -q .*--retry ; then
+        function fetch() {
+            curl -L --retry 20 --remote-time -o "$1" "$2"
+        }
+    else
+        function fetch() {
+            curl -L --remote-time -o "$1" "$2"
+        }
+    fi
+elif command -v wget >/dev/null ; then
+    # In Anaconda images wget is actually busybox
+    if wget --help 2>&1 | grep -q BusyBox ; then
+        function fetch() {
+            wget -O "$1" "$2"
+        }
+    else
+        function fetch() {
+            wget --tries 20 -O "$1" "$2"
+        }
+    fi
+else
+    echo "No HTTP client command available!"
+    function fetch() {
+        false
+    }
+fi
+fetch - http://lab.test-kickstart.invalid:8000/install_fail/@RECIPEID@
+sleep 10
+%end
 
 %post
 set -x

--- a/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
@@ -4146,3 +4146,23 @@ volgroup bootvg --pesize=32768 pv.01
         ks = recipe.installation.rendered_kickstart.kickstart
         self.assertIn("The default Beaker harness repository is not included, because you set 'no_default_harness_repo' via ks_meta", ks)
         self.assertNotIn('[beaker-harness]', ks)
+
+    def test_rhel7_disable_onerror(self):
+        recipe = self.provision_recipe('''
+            <job>
+                <whiteboard/>
+                <recipeSet>
+                    <recipe ks_meta="disable_onerror">
+                        <distroRequires>
+                            <distro_name op="=" value="RHEL-7.0-20120314.0" />
+                            <distro_variant op="=" value="Workstation" />
+                            <distro_arch op="=" value="x86_64" />
+                        </distroRequires>
+                        <hostRequires/>
+                        <task name="/distribution/check-install" />
+                    </recipe>
+                </recipeSet>
+            </job>
+            ''', self.system)
+        ks = recipe.installation.rendered_kickstart.kickstart
+        self.assertNotIn('%onerror', ks)

--- a/LabController/src/bkr/labcontroller/main.py
+++ b/LabController/src/bkr/labcontroller/main.py
@@ -69,6 +69,7 @@ class WSGIApplication(object):
             Rule('/postinstall_done/<recipe_id>',
                     endpoint=(self.proxy, 'postinstall_done')),
             Rule('/postreboot/<recipe_id>', endpoint=(self.proxy, 'postreboot')),
+            Rule('/install_fail/<recipe_id>/', endpoint=(self.proxy, 'install_fail')),
             # harness API:
             Rule('/recipes/<recipe_id>/', methods=['GET'],
                     endpoint=(self.proxy_http, 'get_recipe')),

--- a/LabController/src/bkr/labcontroller/proxy.py
+++ b/LabController/src/bkr/labcontroller/proxy.py
@@ -629,6 +629,11 @@ class Proxy(ProxyHelper):
         logger.debug("install_done recipe_id=%s fqdn=%s", recipe_id, fqdn)
         return self.hub.recipes.install_done(recipe_id, fqdn)
 
+    def install_fail(self, recipe_id=None):
+        _debug_id = "(unspecified recipe)" if recipe_id is None else recipe_id
+        logger.debug("install_fail for R:%s", _debug_id)
+        return self.hub.recipes.install_fail(recipe_id)
+
     def postinstall_done(self, recipe_id=None):
         logger.debug("postinstall_done recipe_id=%s", recipe_id)
         return self.hub.recipes.postinstall_done(recipe_id)

--- a/Server/bkr/server/kickstarts/default
+++ b/Server/bkr/server/kickstarts/default
@@ -109,6 +109,7 @@ chrony
 {% snippet 'system_post' %}
 %end
 
+{% snippet 'onerror' %}
 {{ ks_appends|join('\n') }}
 {% snippet 'postinstall_done' %}
 {% snippet 'post_s390_reboot' %}

--- a/Server/bkr/server/model/distrolibrary.py
+++ b/Server/bkr/server/model/distrolibrary.py
@@ -115,6 +115,10 @@ def default_install_options_for_distro(osmajor_name, osminor, variant, arch):
     ks_meta['has_unsupported_hardware'] = True
     if rhel == '5':
         del ks_meta['has_unsupported_hardware']
+    # support for %onerror
+    ks_meta['has_onerror'] = True
+    if rhel in ('5', '6'):
+        del ks_meta['has_onerror']
 
     # mode
     if rhel == '6':

--- a/Server/bkr/server/recipes.py
+++ b/Server/bkr/server/recipes.py
@@ -240,6 +240,21 @@ class Recipes(RPCRoot):
 
     @cherrypy.expose
     @identity.require(identity.not_anonymous())
+    def install_fail(self, recipe_id=None):
+        """
+        Records the fail of a recipe's installation.
+        """
+        try:
+            recipe = Recipe.by_id(recipe_id)
+        except InvalidRequestError:
+            raise BX(_("Invalid Recipe ID {}".format(recipe_id)))  # noqa: F821
+        if not recipe.installation:
+            raise BX(_("Recipe {} not provisioned yet".format(recipe_id)))  # noqa: F821
+
+        return recipe.abort('Installation failed')
+
+    @cherrypy.expose
+    @identity.require(identity.not_anonymous())
     def postinstall_done(self, recipe_id=None):
         """
         Report completion of postinstallation

--- a/Server/bkr/server/snippets/onerror
+++ b/Server/bkr/server/snippets/onerror
@@ -1,0 +1,8 @@
+{% if has_onerror is defined and recipe %}
+%onerror
+set -x
+{% snippet 'fetch_wrapper' %}
+fetch - http://{{ lab_controller.fqdn }}:8000/install_fail/{{ recipe.id }}
+sleep 10
+{{ end }}
+{% endif %}

--- a/Server/bkr/server/snippets/onerror
+++ b/Server/bkr/server/snippets/onerror
@@ -1,4 +1,4 @@
-{% if has_onerror is defined and recipe %}
+{% if disable_onerror is undefined and has_onerror is defined and recipe %}
 %onerror
 set -x
 {% snippet 'fetch_wrapper' %}

--- a/documentation/user-guide/customizing-installation.rst
+++ b/documentation/user-guide/customizing-installation.rst
@@ -216,6 +216,11 @@ For example in the job XML::
     tree under the :guilabel:`Repos` tab on the distro tree page.
     For example disable_debug_repos.
 
+``disable_onerror``
+    Don't add the ``%onerror`` section to the kickstart. By default the section
+    is added for RHEL 7 and newer. It handles the installation failure reporting
+    it to Beaker and aborting the recipe. This option disables this functionality.
+
 ``ethdevices=<module>[,<module>...]``
     Comma-separated list of network modules to be loaded during installation.
 


### PR DESCRIPTION
At this point, we are scraping the output of `console.log` and trying to match with `known` issues. This may help a bit but this is not definitely good solution.
Because
- Not all machines have console attached - In the worst case there is no console for any machine
- Strings are always changing and we have to add a new 
- Reservesys Workflow completely ignores installation failures. It has a disabled panic feature by default.

Instead of that, we may use the kickstart feature `%onerror` [docs](https://pykickstart.readthedocs.io/en/latest/kickstart-docs.html#chapter-7-handling-errors)
This should be shipped in RHEL7+. This means that all Fedoras will be covered by this as well.