### PR TITLE
Add support to control power from harness API

### DIFF
--- a/LabController/src/bkr/labcontroller/main.py
+++ b/LabController/src/bkr/labcontroller/main.py
@@ -100,6 +100,7 @@ class WSGIApplication(object):
             Rule('/recipes/<recipe_id>/tasks/<task_id>/results/<result_id>/logs/<path:path>',
                     methods=['GET', 'PUT'],
                     endpoint=(self.proxy_http, 'do_result_log')),
+            Rule('/power/<fqdn>/', methods=['PUT'], endpoint=(self.proxy_http, 'put_power'))
         ])
 
     @LimitedRequest.application

--- a/LabController/src/bkr/labcontroller/proxy.py
+++ b/LabController/src/bkr/labcontroller/proxy.py
@@ -1013,3 +1013,27 @@ class ProxyHTTP(object):
             else:
                 raise
         return self._log_index(req, logs)
+
+    def put_power(self, req, fqdn):
+        """
+        Controls power for the system with the given fully-qualified domain
+        name.
+
+        :param req: request
+        :param fqdn: fully-qualified domain name of the system to be power controlled
+        """
+        if req.json:
+            payload = dict(req.json)
+        elif req.form:
+            payload = req.form.to_dict()
+        else:
+            raise UnsupportedMediaType
+
+        if 'action' not in payload:
+            raise BadRequest('Missing "action" parameter')
+        action = payload['action']
+        if action not in ['on', 'off', 'reboot']:
+            raise BadRequest('Unknown action {}'.format(action))
+
+        self.hub.systems.power(action, fqdn, False, True)
+        return Response(status=204)

--- a/documentation/alternative-harnesses/index.rst
+++ b/documentation/alternative-harnesses/index.rst
@@ -208,3 +208,16 @@ the request body must be given as HTML form data
    an Atom feed (:mimetype:`application/atom+xml`). Use the 
    :mailheader:`Accept` header to request a particular representation. The 
    default is HTML.
+
+.. http:put:: /power/(fqdn)/
+
+   Commands Beaker to perform given power action on system defined by FQDN.
+   The request must be :mimetype:`application/x-www-form-urlencoded` or
+   :mimetype:`application/json`.
+
+   :form action:
+        Must be *on*, *off*, or *reboot*.
+   :status 204:
+        The command was successfully executed.
+   :status 400:
+        Bad parameters were given.


### PR DESCRIPTION
At this point, we are missing support for power management (controlled by Beaker) via HTTP API.
However, you can achieve this through the XMLRPC API. This PR should address this problem and mimic the behavior.

Fixes: #17 
Signed-off-by: Martin Styk <mastyk@redhat.com>