### PR TITLE
Change authentication cookie to a persistent cookie

### DIFF
--- a/Server/bkr/server/identity.py
+++ b/Server/bkr/server/identity.py
@@ -154,10 +154,13 @@ def clear_authentication():
         del flask.g._beaker_proxied_by_user
 
 def update_response(response):
+    # visit.timeout (from TG) is in minutes, max_age is in seconds
+    max_age = int(config.get('visit.timeout')) * 60
     if hasattr(flask.g, '_beaker_validated_user'):
-        response.set_cookie(_token_cookie_name, _generate_token())
+        response.set_cookie(_token_cookie_name, _generate_token(),
+                            max_age=max_age)
     else:
-        response.set_cookie(_token_cookie_name, 'deleted')
+        response.set_cookie(_token_cookie_name, 'deleted', max_age=max_age)
     return response
 
 # Mimics the identity.current interface (SqlAlchemyIdentity) from TurboGears:


### PR DESCRIPTION
This is a quality of life improvement. Previous beaker used session
cookies. So when you close your browser the cookie would disappear and
then you would need to login again the next time you went to the
server.

Now we set a persistent cookie which has its expiration set based on
the "visit.timeout" value in the Beaker server.cfg file.

Fixes: #19