### PR TITLE
distro-trees-list: Return ks_meta & kernel_options_post

### DIFF
--- a/Server/bkr/server/distrotrees.py
+++ b/Server/bkr/server/distrotrees.py
@@ -352,6 +352,8 @@ gpgcheck=0
                  'variant': dt.variant,
                  'images' : [(unicode(image.image_type), image.path) for image in dt.images],
                  'kernel_options': dt.kernel_options or u'',
+                 'kernel_options_post': dt.kernel_options_post or u'',
+                 'ks_meta': dt.ks_meta or u'',
                  'available': [(lca.lab_controller.fqdn, lca.url) for lca in dt.lab_controller_assocs],
                 } for dt in query]
 


### PR DESCRIPTION
When calling distro-trees-list now also return ks_meta and
kernel_options_post. Currently it already returns kernel_options.

This is useful for scripting when wanting to know what the ks_meta and
kernel_options_post values are.

This will now be seen when doing:
$ bkr distro-trees-list --format=json