### PR TITLE
beaker-import: Add --preserve-install-options argument

### DIFF
--- a/documentation/admin-guide/man/beaker-import.rst
+++ b/documentation/admin-guide/man/beaker-import.rst
@@ -85,6 +85,12 @@ Options
 
    Add variables to use in kickstart templates
 
+.. option:: --preserve-install-options
+
+   Do not overwrite the *'Install Options' (Kickstart Metadata, Kernel Options,
+   & Kernel Options Post)* already stored for the distro. This option can not be
+   used with any of --kopts, --kopts-post, or --ks-meta
+
 .. option:: --buildtime <buildtime>
 
    Specify build time


### PR DESCRIPTION
When beaker-import does an import it will by default overwrite any
''Install Options' (Kickstart Metadata, Kernel Options, & Kernel
Options Post) that may already be set for the distro.

This new option --preserve-install-options will change the behavior so
that it won't overwrite any previously stored values for the distro.
This can be useful when you have multiple lab controllers and roll out
a distro first to one lab controller and spend time setting up the
correct Install Options. Once that is done you decide to do a
beaker-import on the other lab controllers and don't want to lose your
Install Options.

Fixes: #24