### PR TITLE
Don't set empty default values

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-manual-defaults-beaker-create-kickstart.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-manual-defaults-beaker-create-kickstart.expected
@@ -269,17 +269,17 @@ setenv BEAKER_RECIPE_WHITEBOARD ''
 EOF
 cat << EOF > /etc/profile.d/rh-env.sh
 export LAB_CONTROLLER=lab.test-kickstart.invalid
-export DUMPSERVER=
+#export DUMPSERVER=
 #export NFSSERVERS="RHEL3,fqdn:path RHEL4,fqdn:path RHEL5,fqdn:path RHEL6,fqdn:path NETAPP,fqdn:path SOLARIS,fqdn:path"
-export LOOKASIDE=
-export BUILDURL=
+#export LOOKASIDE=
+#export BUILDURL=
 EOF
 cat << EOF > /etc/profile.d/rh-env.csh
 setenv LAB_CONTROLLER lab.test-kickstart.invalid
-setenv DUMPSERVER 
+#setenv DUMPSERVER
 #setenv NFSSERVERS "RHEL3,fqdn:path RHEL4,fqdn:path RHEL5,fqdn:path RHEL6,fqdn:path NETAPP,fqdn:path SOLARIS,fqdn:path"
-setenv LOOKASIDE 
-setenv BUILDURL 
+#setenv LOOKASIDE
+#setenv BUILDURL
 EOF
 # no snippet data for RedHatEnterpriseLinux6_post
 # no snippet data for RedHatEnterpriseLinux_post

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults-beaker-create-kickstart.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults-beaker-create-kickstart.expected
@@ -427,17 +427,17 @@ setenv BEAKER_RECIPE_WHITEBOARD ''
 EOF
 cat << EOF > /etc/profile.d/rh-env.sh
 export LAB_CONTROLLER=lab.test-kickstart.invalid
-export DUMPSERVER=
+#export DUMPSERVER=
 #export NFSSERVERS="RHEL3,fqdn:path RHEL4,fqdn:path RHEL5,fqdn:path RHEL6,fqdn:path NETAPP,fqdn:path SOLARIS,fqdn:path"
-export LOOKASIDE=
-export BUILDURL=
+#export LOOKASIDE=
+#export BUILDURL=
 EOF
 cat << EOF > /etc/profile.d/rh-env.csh
 setenv LAB_CONTROLLER lab.test-kickstart.invalid
-setenv DUMPSERVER 
+#setenv DUMPSERVER
 #setenv NFSSERVERS "RHEL3,fqdn:path RHEL4,fqdn:path RHEL5,fqdn:path RHEL6,fqdn:path NETAPP,fqdn:path SOLARIS,fqdn:path"
-setenv LOOKASIDE 
-setenv BUILDURL 
+#setenv LOOKASIDE
+#setenv BUILDURL
 EOF
 # no snippet data for RedHatEnterpriseLinux6_post
 # no snippet data for RedHatEnterpriseLinux_post

--- a/Server/bkr/server/snippets/lab_env
+++ b/Server/bkr/server/snippets/lab_env
@@ -1,14 +1,14 @@
 cat << EOF > /etc/profile.d/rh-env.sh
 export LAB_CONTROLLER={{ lab_controller.fqdn }}
-export DUMPSERVER=
+#export DUMPSERVER=
 #export NFSSERVERS="RHEL3,fqdn:path RHEL4,fqdn:path RHEL5,fqdn:path RHEL6,fqdn:path NETAPP,fqdn:path SOLARIS,fqdn:path"
-export LOOKASIDE=
-export BUILDURL=
+#export LOOKASIDE=
+#export BUILDURL=
 EOF
 cat << EOF > /etc/profile.d/rh-env.csh
 setenv LAB_CONTROLLER {{ lab_controller.fqdn }}
-setenv DUMPSERVER 
+#setenv DUMPSERVER
 #setenv NFSSERVERS "RHEL3,fqdn:path RHEL4,fqdn:path RHEL5,fqdn:path RHEL6,fqdn:path NETAPP,fqdn:path SOLARIS,fqdn:path"
-setenv LOOKASIDE 
-setenv BUILDURL 
+#setenv LOOKASIDE
+#setenv BUILDURL
 EOF


### PR DESCRIPTION
when using restraint to run tests in DCI we set LOOKASIDE variable
from the job xml but couldn't figure out why it wasn't being set
when the job ran.  This default was overwriting our value.

We worked around this by creating a /etc/beaker/snippets/lab_env
file with nothing in it.

Change-Id: Ie4d66988cc2ccc08c58239d3d23a139027139426