### PR TITLE
Fix kickstart size limitation

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/test_database_migration.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_database_migration.py
@@ -12,6 +12,7 @@ from turbogears import config
 from turbogears.database import metadata
 from bkr.common import __version__
 from bkr.server.tools.init import upgrade_db, downgrade_db, check_db, doit, init_db
+from sqlalchemy import UnicodeText
 from sqlalchemy.orm import create_session
 from sqlalchemy.sql import func
 from bkr.server.model import (
@@ -472,7 +473,8 @@ class MigrationTest(unittest.TestCase):
             self.assertTrue(actual.type._compare_type_affinity(expected.type),
                             'Actual type %r should be equivalent to expected type %r'
                             % (actual.type, expected.type))
-        if hasattr(expected.type, 'length'):
+
+        if hasattr(expected.type, 'length') and not isinstance(expected.type, UnicodeText):
             self.assertEquals(actual.type.length, expected.type.length,
                               '%r has wrong length' % actual)
         if hasattr(expected.type, 'precision'):

--- a/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
@@ -4166,3 +4166,24 @@ volgroup bootvg --pesize=32768 pv.01
             ''', self.system)
         ks = recipe.installation.rendered_kickstart.kickstart
         self.assertNotIn('%onerror', ks)
+
+    def test_kickstart_overflow(self):
+        self.provision_recipe('''
+            <job>
+                <whiteboard/>
+                <recipeSet>
+                    <recipe ks_meta="">
+                        <ks_appends>
+                            {0}
+                        </ks_appends>
+                        <distroRequires>
+                            <distro_name op="=" value="RHEL-7.0-20120314.0" />
+                            <distro_variant op="=" value="Workstation" />
+                            <distro_arch op="=" value="x86_64" />
+                        </distroRequires>
+                        <hostRequires/>
+                        <task name="/distribution/check-install" />
+                    </recipe>
+                </recipeSet>
+            </job>
+            '''.format('<ks_append>{0}</ks_append>'.format('A' * 64000) * 300))

--- a/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
@@ -4168,7 +4168,8 @@ volgroup bootvg --pesize=32768 pv.01
         self.assertNotIn('%onerror', ks)
 
     def test_kickstart_overflow(self):
-        self.provision_recipe('''
+        with self.assertRaises(ValueError):
+            self.provision_recipe('''
             <job>
                 <whiteboard/>
                 <recipeSet>

--- a/Server/bkr/server/alembic/versions/4b3a6065eba2_fix_size_of_rendered_kickstart.py
+++ b/Server/bkr/server/alembic/versions/4b3a6065eba2_fix_size_of_rendered_kickstart.py
@@ -1,0 +1,33 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""
+Fix size of rendered Kickstart
+
+Revision ID: 4b3a6065eba2
+Revises: 4cddc14ab090
+Create Date: 2020-06-08 04:31:21.024268
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '4b3a6065eba2'
+down_revision = '4cddc14ab090'
+
+
+def upgrade():
+    op.alter_column('rendered_kickstart', 'kickstart',
+                    existing_type=sa.UnicodeText(),
+                    type_=sa.UnicodeText(length=262143),
+                    existing_nullable=True)
+
+
+def downgrade():
+    op.alter_column('rendered_kickstart', 'kickstart',
+                    existing_type=sa.UnicodeText(length=262143),
+                    type_=sa.UnicodeText(),
+                    existing_nullable=True)

--- a/Server/bkr/server/kickstart.py
+++ b/Server/bkr/server/kickstart.py
@@ -14,6 +14,7 @@ import jinja2.nodes
 import jinja2.sandbox
 import netaddr
 from flask import redirect, abort, Response
+from sqlalchemy.exc import DataError
 from sqlalchemy.orm.exc import NoResultFound
 
 from bkr.server.app import app
@@ -337,7 +338,10 @@ def generate_kickstart(install_options, distro_tree, system, user,
 
     rendered_kickstart = RenderedKickstart(kickstart=result)
     session.add(rendered_kickstart)
-    session.flush()  # so that it has an id
+    try:
+        session.flush()  # so that it has an id
+    except DataError:
+        raise ValueError('Kickstart generation failed. Please report this issue.')
     return rendered_kickstart
 
 

--- a/Server/bkr/server/model/installation.py
+++ b/Server/bkr/server/model/installation.py
@@ -121,7 +121,7 @@ class RenderedKickstart(DeclarativeMappedObject):
     id = Column(Integer, primary_key=True)
     # Either kickstart or url should be populated -- if url is present,
     # it means fetch the kickstart from there instead
-    kickstart = Column(UnicodeText)
+    kickstart = Column(UnicodeText(length=2**18-1))
     url = Column(UnicodeText)
 
     def __repr__(self):

--- a/Server/bkr/server/tools/beakerd.py
+++ b/Server/bkr/server/tools/beakerd.py
@@ -597,8 +597,8 @@ def provision_scheduled_recipeset(recipeset_id):
             recipe.waiting()
             recipe.provision()
         except Exception as e:
-            log.exception("Failed to provision recipeid %s", recipe.id)
             session.rollback()
+            log.exception("Failed to provision recipeid %s", recipe.id)
             session.begin()
             recipe.recipeset.abort(u"Failed to provision recipeid %s, %s" % (recipe.id, e))
             return


### PR DESCRIPTION
At this point is really easy to breach 65k characters in rendered kickstart.
The easiest way to achieve that is to running jobs as Group and ask them
to add their SSH key into account. Beaker will take every single one SSH key
and put it into kickstart. The database will fail to store it and we will end up an infinite loop.
Where scheduler is trying to reschedule it again and again.

Bug: [1796851](https://bugzilla.redhat.com/show_bug.cgi?id=1796851)

Signed-off-by: Martin Styk <mastyk@redhat.com>