### PR TITLE
Allow user to define harness in ks_meta multiple times

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
@@ -4188,3 +4188,24 @@ volgroup bootvg --pesize=32768 pv.01
                 </recipeSet>
             </job>
             '''.format('<ks_append>{0}</ks_append>'.format('A' * 64000) * 300))
+
+    def test_multiple_harness_ks_meta(self):
+        recipe = self.provision_recipe('''
+            <job>
+                <whiteboard>Define harness ks_meta twice</whiteboard>
+                <recipeSet>
+                    <recipe ks_meta="harness='great-restraint' harness='dead-beah'">
+                        <distroRequires>
+                            <distro_name op="=" value="RHEL-7.0-20120314.0" />
+                            <distro_variant op="=" value="Workstation" />
+                            <distro_arch op="=" value="x86_64" />
+                        </distroRequires>
+                        <hostRequires/>
+                        <task name="/distribution/check-install" />
+                    </recipe>
+                </recipeSet>
+            </job>
+            ''', self.system)
+        ks = recipe.installation.rendered_kickstart.kickstart
+        ks_lines = ks.splitlines()
+        self.assert_('$package_command -y install great-restraint dead-beah' in ks_lines, ks)

--- a/Server/bkr/server/snippets/harness
+++ b/Server/bkr/server/snippets/harness
@@ -24,8 +24,8 @@ fi
 # the environment clean. (multilib_policy=best is the default in RHEL6+.)
 cp -p /etc/yum.conf{,.orig}
 echo multilib_policy=best >>/etc/yum.conf
-$package_command{{ ' ' + yum_install_extra_opts if yum_install_extra_opts is defined else '' }} -y install {{ harness }}
+$package_command{{ ' ' + yum_install_extra_opts if yum_install_extra_opts is defined else '' }} -y install {{ harness if harness is string else harness|join(' ')}}
 mv /etc/yum.conf{.orig,}
 {% else %}
-$package_command{{ ' ' + yum_install_extra_opts if yum_install_extra_opts is defined else '' }} -y install {{ harness }}
+$package_command{{ ' ' + yum_install_extra_opts if yum_install_extra_opts is defined else '' }} -y install {{ harness if harness is string else harness|join(' ')}}
 {% endif %}


### PR DESCRIPTION
Following definition should be considered as valid
```XML
<recipe ks_meta="harness=restraint-rhts-0.1.44 harness='restraint-rhts beakerlib-redhat' ">
```

Bug: [1803555](https://bugzilla.redhat.com/show_bug.cgi?id=1803555)
It is expected that we will merge all items and make DNF resolve the situation