### PR TITLE
Don't add XML element system_type when user already defined type

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/test_model.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_model.py
@@ -1900,6 +1900,22 @@ class RecipeTest(DatabaseTestCase):
                     u'</and>'
                 u'</hostRequires>')
 
+        # Make sure system_type is not added when
+        # system/type is already defined in hostRequires
+        recipe_system_type = data_setup.create_recipe()
+        recipe_st_host_requires = (
+            u'<hostRequires>'
+            u'<and>'
+            u'<system>'
+            u'<type op="=" value="Resource"/>'
+            u'</system>'
+            u'</and>'
+            u'</hostRequires>'
+        )
+        recipe_system_type.host_requires = recipe_st_host_requires
+
+        self.assertEquals(recipe_system_type.host_requires, recipe_st_host_requires)
+
     # https://bugzilla.redhat.com/show_bug.cgi?id=1240809
     def test_get_all_logs(self):
         job = data_setup.create_completed_job(server_log=True)

--- a/Server/bkr/server/model/scheduler.py
+++ b/Server/bkr/server/model/scheduler.py
@@ -2313,8 +2313,10 @@ class Recipe(TaskBase, ActivityMixin):
         except ValueError:
             hrs = etree.Element('hostRequires')
 
-        # If no system_type is specified then add defaults
-        if not hrs.findall('.//system_type') and not hrs.get('force'):
+        # If no system_type or system/type is not specified then add default value
+        if (not hrs.findall('.//system_type')
+                and not hrs.findall('.//system/type')
+                and not hrs.get('force')):
             system_type = etree.Element('system_type')
             system_type.set('value', unicode(self.systemtype))
             hrs.append(system_type)


### PR DESCRIPTION
Make sure we are not adding `system_type` XML element in case the user already defines `system/type`.

Bug: [1851464](https://bugzilla.redhat.com/show_bug.cgi?id=1851464)