### PR TITLE
Use reference to GitHub rather than BZ

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/selenium/test_help.py
+++ b/IntegrationTests/src/bkr/inttest/server/selenium/test_help.py
@@ -21,4 +21,4 @@ class TestHelp(WebDriverTestCase):
         b.find_element_by_xpath("//ul[@id='help-menu']//a[text()='Documentation' \
                                 and @href='http://beaker-project.org/docs/']")
         b.find_element_by_xpath("//ul[@id='help-menu']//a[text()='Report a Bug' \
-                                and @href='https://bugzilla.redhat.com/enter_bug.cgi?product=Beaker']")
+                                and @href='https://github.com/beaker-project/beaker/issues/']")

--- a/Server/bkr/server/config/app.cfg
+++ b/Server/bkr/server/config/app.cfg
@@ -100,7 +100,7 @@ beaker.inventory_osmajors = ['RedHatEnterpriseLinux8', 'RedHatEnterpriseLinux7',
 # gzip_filter.on = True
 # gzip_filter.mime_types = ["application/x-javascript", "text/javascript", "text/html", "text/css", "text/plain"]
 
-beaker.bz_create_link = "https://bugzilla.redhat.com/enter_bug.cgi?product=Beaker"
+beaker.issue_create_link = "https://github.com/beaker-project/beaker/issues/"
 beaker.documentation_link = 'http://beaker-project.org/docs/'
 
 [/logs]

--- a/Server/bkr/server/templates/master.kid
+++ b/Server/bkr/server/templates/master.kid
@@ -160,7 +160,7 @@ from bkr.server.reports import Reports
               </a>
               <ul class="dropdown-menu" id="help-menu">
                 <li><a href="${tg.config('beaker.documentation_link')}">Documentation</a></li>
-                <li><a href="${tg.config('beaker.bz_create_link')}">Report a Bug</a></li>
+                <li><a href="${tg.config('beaker.issue_create_link')}">Report a Bug</a></li>
               </ul>
             </li>
         </ul>

--- a/documentation/admin-guide/reporting-queries.rst
+++ b/documentation/admin-guide/reporting-queries.rst
@@ -40,7 +40,6 @@ must then examine the detailed schema upgrade notes for that release and
 ensure the reporting tool's queries are updated as necessary. 
 
 Suggestions for additional supported queries are welcome, and may be filed
-as enhancement requests for the `Beaker community project`_ in Red Hat's
-Bugzilla instance. 
+as enhancement requests for the `Beaker community project`_ in GitHub.
 
-.. _Beaker community project: https://bugzilla.redhat.com/enter_bug.cgi?product=Beaker
+.. _Beaker community project: https://github.com/beaker-project/beaker/issues/

--- a/documentation/index.rst
+++ b/documentation/index.rst
@@ -68,9 +68,8 @@ You can also ask your question by posting it to our `beaker-devel
 <https://lists.fedorahosted.org/archives/list/beaker-devel@lists.fedorahosted.org/>`_
 mailing list.
 
-If you've found a bug in Beaker, please report it in `Red Hat Bugzilla 
-<https://bugzilla.redhat.com/enter_bug.cgi?product=Beaker>`__ against the 
-Beaker product.
+If you've found a bug in Beaker, please report it in `GitHub project
+<https://github.com/beaker-project/beaker/issues>`__.
 
 Presentations about Beaker
 ==========================


### PR DESCRIPTION
At this point we **should** point all incoming issues to GitHub rather than Bugzilla.

Signed-off-by: Martin Styk <mastyk@redhat.com>