### PR TITLE
Use Restraint-RHTS as default test harness

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-scheduler-defaults.expected
@@ -38,10 +38,7 @@ autopart
 # no snippet data for system
 
 %packages --ignoremissing
-emacs
-sendmail
-unifdef
-vim-enhanced
+# Task requirements will be installed by the harness
 # no snippet data for packages
 chrony
 %end
@@ -302,54 +299,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test01.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-systemctl enable beah-srv.service
-systemctl enable beah-beaker-backend.service
-systemctl enable beah-fwd-backend.service
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RHVH-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RHVH-defaults.expected
@@ -284,54 +284,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test01.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-systemctl enable beah-srv.service
-systemctl enable beah-beaker-backend.service
-systemctl enable beah-fwd-backend.service
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults-beaker-create-kickstart.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults-beaker-create-kickstart.expected
@@ -44,10 +44,7 @@ autopart
 # no snippet data for system
 
 %packages --ignoremissing
-emacs
-sendmail
-unifdef
-vim-enhanced
+# Task requirements will be installed by the harness
 # no snippet data for packages
 %end
 
@@ -358,60 +355,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test01.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# Also send logs to /dev/console.
-CONSOLE_LOG=Console
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-chkconfig --level 345 beah-srv on
-chkconfig --level 345 beah-beaker-backend on
-chkconfig --level 345 beah-fwd-backend on
-
-# turn on rhts-compat by default (it will save us one reboot):
-chkconfig --add rhts-compat
-chkconfig --level 345 rhts-compat on
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults.expected
@@ -44,10 +44,7 @@ autopart
 # no snippet data for system
 
 %packages --ignoremissing
-emacs
-sendmail
-unifdef
-vim-enhanced
+# Task requirements will be installed by the harness
 # no snippet data for packages
 %end
 
@@ -358,60 +355,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test01.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# Also send logs to /dev/console.
-CONSOLE_LOG=Console
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-chkconfig --level 345 beah-srv on
-chkconfig --level 345 beah-beaker-backend on
-chkconfig --level 345 beah-fwd-backend on
-
-# turn on rhts-compat by default (it will save us one reboot):
-chkconfig --add rhts-compat
-chkconfig --level 345 rhts-compat on
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-guest.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-guest.expected
@@ -44,10 +44,7 @@ autopart
 # no snippet data for system
 
 %packages --ignoremissing
-emacs
-sendmail
-unifdef
-vim-enhanced
+# Task requirements will be installed by the harness
 # no snippet data for packages
 %end
 
@@ -345,56 +342,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# Also send logs to /dev/console.
-CONSOLE_LOG=Console
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-chkconfig --level 345 beah-srv on
-chkconfig --level 345 beah-beaker-backend on
-chkconfig --level 345 beah-fwd-backend on
-
-# turn on rhts-compat by default (it will save us one reboot):
-chkconfig --add rhts-compat
-chkconfig --level 345 rhts-compat on
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-manual.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-manual.expected
@@ -310,60 +310,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test-manual-1.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# Also send logs to /dev/console.
-CONSOLE_LOG=Console
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-chkconfig --level 345 beah-srv on
-chkconfig --level 345 beah-beaker-backend on
-chkconfig --level 345 beah-fwd-backend on
-
-# turn on rhts-compat by default (it will save us one reboot):
-chkconfig --add rhts-compat
-chkconfig --level 345 rhts-compat on
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-defaults.expected
@@ -40,10 +40,7 @@ autopart
 # no snippet data for system
 
 %packages --ignoremissing
-emacs
-sendmail
-unifdef
-vim-enhanced
+# Task requirements will be installed by the harness
 # no snippet data for packages
 chrony
 %end
@@ -333,54 +330,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test01.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-systemctl enable beah-srv.service
-systemctl enable beah-beaker-backend.service
-systemctl enable beah-fwd-backend.service
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-manual.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-manual.expected
@@ -287,54 +287,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test-manual-1.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-systemctl enable beah-srv.service
-systemctl enable beah-beaker-backend.service
-systemctl enable beah-fwd-backend.service
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxAlternateArchitectures7-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxAlternateArchitectures7-scheduler-defaults.expected
@@ -40,10 +40,7 @@ autopart
 # no snippet data for system
 
 %packages --ignoremissing
-emacs
-sendmail
-unifdef
-vim-enhanced
+# Task requirements will be installed by the harness
 # no snippet data for packages
 chrony
 %end
@@ -333,54 +330,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test01.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-systemctl enable beah-srv.service
-systemctl enable beah-beaker-backend.service
-systemctl enable beah-fwd-backend.service
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxServer5-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxServer5-scheduler-defaults.expected
@@ -35,10 +35,7 @@ autopart
 # no snippet data for system
 
 %packages --resolvedeps --ignoremissing
-emacs
-sendmail
-unifdef
-vim-enhanced
+# Task requirements will be installed by the harness
 # no snippet data for packages
 
 
@@ -322,60 +319,25 @@ fi
 # This speeds up yum because of a bug where it will update stdout too often.
 # http://lists.baseurl.org/pipermail/yum-devel/2011-December/008857.html
 $package_command check-update -y > /dev/null 2>&1 || true
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.sh
+export BEAKER_LAB_CONTROLLER_URL="http://lab.test-kickstart.invalid:8000/"
+export BEAKER_LAB_CONTROLLER=lab.test-kickstart.invalid
+export BEAKER_RECIPE_ID=@RECIPEID@
+export BEAKER_HUB_URL="@BEAKER@"
+EOF
+cat <<"EOF" >/etc/profile.d/beaker-harness-env.csh
+setenv BEAKER_LAB_CONTROLLER_URL "http://lab.test-kickstart.invalid:8000/"
+setenv BEAKER_LAB_CONTROLLER lab.test-kickstart.invalid
+setenv BEAKER_RECIPE_ID @RECIPEID@
+setenv BEAKER_HUB_URL "@BEAKER@"
+EOF
+
 if command -v dnf >/dev/null ; then
    package_command="dnf"
 else
    package_command="yum"
 fi
-$package_command -y install beah rhts-test-env
-$package_command -y install beakerlib
-# This may fail if you are outside of Red Hat..
-$package_command -y install beakerlib-redhat
-
-cp /etc/beah_beaker.conf{,.default}
-cat << EOF > /etc/beah_beaker.conf
-# see /etc/beah_beaker.conf.default for commented configuration
-
-[DEFAULT]
-# LAB_CONTROLLER: URI of Beaker's XML-RPC handler
-LAB_CONTROLLER=http://lab.test-kickstart.invalid:8000
-#
-# HOSTNAME: Pretend to be machine with given name.
-# NOTE: This is mostly pointless as usually correct name is assigned by DHCP.
-HOSTNAME=test01.test-kickstart.invalid
-RECIPEID=@RECIPEID@
-
-# Turn on hard limits on upload sizes:
-FILE_SIZE_LIMIT=200000000
-TASK_SIZE_LIMIT=800000000
-
-EOF
-
-cp /etc/beah.conf{,.default}
-cat << EOF > /etc/beah.conf
-# see /etc/beah.conf.default for commented configuration
-
-[DEFAULT]
-# Turn on more verbose logging. This is useful for debugging harness' problems.
-LOG=Info
-# Also send logs to /dev/console.
-CONSOLE_LOG=Console
-# To turn on debug logging uncomment the following line. Warning: this is
-# rather verbose! This also requires LOG to be Debug.
-#DEVEL=True
-
-[TASK]
-INTERFACE=
-
-EOF
-
-chkconfig --level 345 beah-srv on
-chkconfig --level 345 beah-beaker-backend on
-chkconfig --level 345 beah-fwd-backend on
-
-# turn on rhts-compat by default (it will save us one reboot):
-chkconfig --add rhts-compat
-chkconfig --level 345 rhts-compat on
+$package_command -y install restraint-rhts
 
 #Add test user account
 useradd --password '$6$oIW3o2Mr$XbWZKaM7nA.cQqudfDJScupXOia5h1u517t6Htx/Q/MgXm82Pc/OcytatTeI4ULNWOMJzvpCigWiL4xKP9PX4.' test

--- a/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
@@ -1959,7 +1959,7 @@ END
         self.assert_('# Check in with Beaker Server' in klines, k)
         self.assert_('%post --log=/dev/console' in klines, k)
         self.assert_('# Add Harness Repo' in klines, k)
-        self.assert_('$package_command -y install beah rhts-test-env' in klines, k)
+        self.assert_('$package_command -y install restraint-rhts' in klines, k)
 
     def test_custom_kickstart_rhel7(self):
         recipe = self.provision_recipe('''
@@ -2020,7 +2020,7 @@ END
         self.assert_('# Check in with Beaker Server' in klines, k)
         self.assert_('%post --log=/dev/console' in klines, k)
         self.assert_('# Add Harness Repo' in klines, k)
-        self.assert_('$package_command -y install beah rhts-test-env' in klines, k)
+        self.assert_('$package_command -y install restraint-rhts' in klines, k)
 
     def test_custom_kickstart_fedora_rawhide(self):
         recipe = self.provision_recipe('''
@@ -2140,7 +2140,7 @@ END
         self.assert_('# Check in with Beaker Server' in klines, k)
         self.assert_('%post --log=/dev/console' in klines, k)
         self.assert_('# Add Harness Repo' in klines, k)
-        self.assert_('$package_command -y install beah rhts-test-env' in klines, k)
+        self.assert_('$package_command -y install restraint-rhts' in klines, k)
 
 
     # https://bugzilla.redhat.com/show_bug.cgi?id=801676
@@ -2253,6 +2253,7 @@ install
         self.assertIn('''\
 install
 %packages
+# Task requirements will be installed by the harness
 *
 -@conflicts
 %end
@@ -2288,6 +2289,7 @@ install
         self.assertIn('''\
 install
 %packages
+# Task requirements will be installed by the harness
 *
 -@conflicts-workstation
 %end
@@ -2322,12 +2324,13 @@ install
         self.assertIn('''\
 install
 %packages
+# Task requirements will be installed by the harness
 *
 -@conflicts-client
 -@conflicts-server
 -@conflicts-workstation
 %end
-''', ks)
+''', ks, ks)
 
     def test_custom_kickstart_fedora_without_conflicts_groups(self):
         recipe = self.provision_recipe('''
@@ -2358,6 +2361,7 @@ install
         self.assertIn('''\
 install
 %packages
+# Task requirements will be installed by the harness
 *
 %end
 ''', ks)
@@ -2994,7 +2998,7 @@ network --bootproto=dhcp --device=66:77:88:99:aa:bb
             <job>
                 <whiteboard/>
                 <recipeSet>
-                    <recipe>
+                    <recipe ks_meta="install_task_requires">
                         <distroRequires>
                             <distro_name op="=" value="RHEL-6.2" />
                             <distro_variant op="=" value="Server" />
@@ -3057,7 +3061,7 @@ httpd
             <job>
                 <whiteboard/>
                 <recipeSet>
-                    <recipe>
+                    <recipe ks_meta="install_task_requires">
                         <distroRequires>
                             <distro_name op="=" value="RHEL-6.2" />
                             <distro_variant op="=" value="Server" />
@@ -3668,7 +3672,7 @@ part /boot --recommended --asprimary --fstype ext4 --ondisk=vdb
             <job>
                 <whiteboard/>
                 <recipeSet>
-                    <recipe ks_meta="beah_rpm=beah-0.6.48">
+                    <recipe ks_meta="harness=beah beah_rpm=beah-0.6.48">
                         <distroRequires>
                             <distro_name op="=" value="RHEL-7.0-20120314.0" />
                             <distro_variant op="=" value="Workstation" />
@@ -3688,7 +3692,7 @@ part /boot --recommended --asprimary --fstype ext4 --ondisk=vdb
             <job>
                 <whiteboard/>
                 <recipeSet>
-                    <recipe ks_meta="beah_no_ipv6">
+                    <recipe ks_meta="beah_no_ipv6 harness=beah">
                         <distroRequires>
                             <distro_name op="=" value="RHEL5-Server-U8" />
                             <distro_arch op="=" value="ia64" />
@@ -4089,7 +4093,7 @@ volgroup bootvg --pesize=32768 pv.01
             <job>
                 <whiteboard/>
                 <recipeSet>
-                    <recipe>
+                    <recipe ks_meta="harness=beah">
                         <distroRequires>
                             <distro_name op="=" value="Fedora-18" />
                             <distro_arch op="=" value="x86_64" />

--- a/Server/bkr/server/model/distrolibrary.py
+++ b/Server/bkr/server/model/distrolibrary.py
@@ -61,13 +61,9 @@ def default_install_options_for_distro(osmajor_name, osminor, variant, arch):
     # override these in OS major or distro install options if necessary.
     ks_meta = {}
 
-    # Default harness is set to restraint. We opt out of restraint for any
-    # distro prior to RHEL8 and Fedora 29.
+    # Default harness for all distributions
+    # User can always opt-out by defining harness in ks_meta
     ks_meta['harness'] = 'restraint-rhts'
-    if (rhel and int(rhel) < 8 or \
-        fedora and fedora != 'rawhide' and int(fedora) < 29):
-        ks_meta['harness'] = 'beah'
-        ks_meta['install_task_requires'] = True
 
     # %end
     ks_meta['end'] = '%end'


### PR DESCRIPTION
Following topic are covered by this PR:
- By default, Restraint-RHTS is passed as `harness`
- Beah is still usable. The user has to define it in ks_meta. Due to Beah dep limitation user should use a combination of `harness=beah install_task_requires` in `ks_meta`
- Note ` # Task requirements will be installed by the harness ` always appears in `%package` section as Beaker is always taking special threatment to it. No matter if user will define it in kickstart or when it is generated fully by Beaker. 
Fix: #32 