### PR TITLE
Hide power managment password by default

### DIFF
--- a/Server/assets/jst/system-power-settings.html
+++ b/Server/assets/jst/system-power-settings.html
@@ -24,9 +24,13 @@
   <div class="control-group">
     <label class="control-label" for="power_password">Power Password</label>
     <div class="controls">
-      <input type="text" id="power_password" name="power_password" />
+      <div class="input-append" id="show_password">
+        <input type="password" id="power_password" name="power_password" />
+        <button class="btn" type="button"><i class="fa fa-eye" aria-hidden="true"></i></button>
+      </div>
     </div>
   </div>
+
   <div class="control-group">
     <label class="control-label" for="power_id">Power ID</label>
     <div class="controls">

--- a/Server/assets/system-power-settings.js
+++ b/Server/assets/system-power-settings.js
@@ -10,6 +10,7 @@ window.SystemPowerSettingsView = Backbone.View.extend({
     template: JST['system-power-settings'],
     events: {
         'click #reprovision_distro_tree button': 'pick_reprovision_distro_tree',
+        'click #show_password button': 'showPassword',
         'submit form': 'submit',
         'reset form': 'reset',
     },
@@ -58,6 +59,14 @@ window.SystemPowerSettingsView = Backbone.View.extend({
             view.$('[name=reprovision_distro_tree_id]').val(selection.get('distro_tree_id'));
             view.$('#reprovision_distro_tree span').text(selection.get('distro_tree_label'));
         });
+    },
+    showPassword: function (evt) {
+        evt.preventDefault()
+        this.$("#show_password i").toggleClass('fa-eye').toggleClass('fa-eye-slash')
+
+        this.$("#show_password input").attr("type") === "password"
+            ? this.$("#show_password input").attr('type', 'text')
+            : this.$("#show_password input").attr('type', 'password')
     },
     sync_success: function (response, status, xhr) {
         this.$('.form-actions button').button('reset');


### PR DESCRIPTION
Users can toggle to see the password assigned to the given machine. By default password is hidden.


_Default:_
![image](https://user-images.githubusercontent.com/188918/87286389-1a938e00-c4f9-11ea-973f-f83e40b34fd0.png)

_Toggled:_
![image](https://user-images.githubusercontent.com/188918/87286439-28491380-c4f9-11ea-89f4-7d8debe59174.png)

Fixes: #48 
Signed-off-by: Martin Styk <mastyk@redhat.com>