### PR TITLE
Use proper macro for python 3 files

### DIFF
--- a/beaker.spec
+++ b/beaker.spec
@@ -420,7 +420,7 @@ chmod go-w %{_localstatedir}/log/%{name}/*.log >/dev/null 2>&1 || :
 %{python3_sitelib}/bkr/common/
 %{python3_sitelib}/bkr/log.py*
 %{python3_sitelib}/bkr/__pycache__/*
-%{python3_sitelib}/beaker_common-*.egg-info/
+%{python3_sitelib}/%{name}_common-%{version}-py%{python3_version}.egg-info/
 %else
 %dir %{python2_sitelib}/bkr/
 %{python2_sitelib}/bkr/__init__.py*
@@ -488,8 +488,8 @@ chmod go-w %{_localstatedir}/log/%{name}/*.log >/dev/null 2>&1 || :
 %doc Client/client.conf.example
 %if %{with python3}
 %{python3_sitelib}/bkr/client/
-%{python3_sitelib}/beaker_client-*-nspkg.pth
-%{python3_sitelib}/beaker_client-*.egg-info/
+%{python3_sitelib}/%{name}_client-%{version}-py%{python3_version}-nspkg.pth
+%{python3_sitelib}/%{name}_client-%{version}-py%{python3_version}.egg-info/
 %else
 %{python2_sitelib}/bkr/client/
 %{python2_sitelib}/beaker_client-*-nspkg.pth


### PR DESCRIPTION
We should be more explict about content and what we are putting there.

This is backport from upstream specfile

Signed-off-by: Martin Styk <mastyk@redhat.com>