### PR TITLE
Drop Python 2.6 references

### DIFF
--- a/Client/src/bkr/client/commands/cmd_policy_grant.py
+++ b/Client/src/bkr/client/commands/cmd_policy_grant.py
@@ -24,8 +24,6 @@ Description
 
 Modifies the access policy to grant new permissions to the given users or groups.
 
-(Note: this command requires Python 2.6 or later)
-
 Options
 -------
 

--- a/Client/src/bkr/client/commands/cmd_policy_list.py
+++ b/Client/src/bkr/client/commands/cmd_policy_list.py
@@ -26,8 +26,6 @@ By default, the currently *active* access policy rules are retrieved,
 which could be a a pool access policy. To retrieve the custom access
 policy rules, specify ``--custom``.
 
-(Note: this command requires Python 2.6 or later)
-
 Options
 -------
 

--- a/Client/src/bkr/client/commands/cmd_policy_revoke.py
+++ b/Client/src/bkr/client/commands/cmd_policy_revoke.py
@@ -24,8 +24,6 @@ Description
 
 Modifies the access policy to revoke permissions for the given users or groups.
 
-(Note: this command requires Python 2.6 or later)
-
 Options
 -------
 

--- a/Client/src/bkr/client/commands/cmd_pool_add.py
+++ b/Client/src/bkr/client/commands/cmd_pool_add.py
@@ -24,8 +24,6 @@ Description
 
 Adds systems to an existing system pool.
 
-(Note: this command requires Python 2.6 or later)
-
 .. versionadded:: 20
 
 Options

--- a/Client/src/bkr/client/commands/cmd_pool_create.py
+++ b/Client/src/bkr/client/commands/cmd_pool_create.py
@@ -26,8 +26,6 @@ Creates a Beaker system pool. By default the new pool is owned by the
 user who created it. To set a different owner, use the
 :option:`--owning-group` or :option:`--owner` options.
 
-(Note: this command requires Python 2.6 or later)
-
 .. versionadded:: 20
 
 Options

--- a/Client/src/bkr/client/commands/cmd_pool_delete.py
+++ b/Client/src/bkr/client/commands/cmd_pool_delete.py
@@ -22,8 +22,6 @@ Description
 
 Deletes a Beaker system pool.
 
-(Note: this command requires Python 2.6 or later)
-
 .. versionadded:: 20
 
 Common :program:`bkr` options are described in the :ref:`Options

--- a/Client/src/bkr/client/commands/cmd_pool_modify.py
+++ b/Client/src/bkr/client/commands/cmd_pool_modify.py
@@ -23,8 +23,6 @@ Description
 
 Modify the name, description or owner of an existing system pool.
 
-(Note: this command requires Python 2.6 or later)
-
 .. versionadded:: 20
 
 Options

--- a/Client/src/bkr/client/commands/cmd_pool_remove.py
+++ b/Client/src/bkr/client/commands/cmd_pool_remove.py
@@ -24,8 +24,6 @@ Description
 
 Removes systems from a system pool.
 
-(Note: this command requires Python 2.6 or later)
-
 .. versionadded:: 20
 
 Options

--- a/Client/src/bkr/client/commands/cmd_update_inventory.py
+++ b/Client/src/bkr/client/commands/cmd_update_inventory.py
@@ -35,7 +35,6 @@ customizing your job.
 Common :program:`bkr` options are described in the :ref:`Options
 <common-options>` section of :manpage:`bkr(1)`.
 
-(Note: this command requires Python 2.6 or later)
 
 .. versionadded:: 21
 

--- a/IntegrationTests/src/bkr/inttest/server/test_database_migration.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_database_migration.py
@@ -988,7 +988,8 @@ class MigrationTest(unittest.TestCase):
                 "INSERT INTO activity (id, user_id, created, type, field_name, "
                 "   service, action, old_value, new_value) "
                 "VALUES (1, 1, '2016-08-11 16:47:56', 'command_activity', 'Command', "
-                "   'Scheduler', 'on', '', 'ValueError: Power script /usr/lib/python2.6/site-packages/bk')")
+                "   'Scheduler', 'on', '', "
+                "   'ValueError: Power script /usr/lib/python2.7/site-packages/bk')")
             connection.execute(
                 "INSERT INTO command_queue (id, system_id, status, updated, quiescent_period) "
                 "VALUES (1, 1, 'Failed', '2016-08-11 16:47:56', 5)")
@@ -1013,7 +1014,7 @@ class MigrationTest(unittest.TestCase):
         self.assertEquals(cmd.delay_until, None)
         self.assertEquals(cmd.status, CommandStatus.failed)
         self.assertEquals(cmd.error_message,
-                          u'ValueError: Power script /usr/lib/python2.6/site-packages/bk')
+                          u'ValueError: Power script /usr/lib/python2.7/site-packages/bk')
         # old activity row should be gone
         self.assertIsNone(self.migration_session.query(Activity).filter_by(id=1).first())
         # insert a new command after upgrade, as if Beaker has been running for a while
@@ -1044,7 +1045,7 @@ class MigrationTest(unittest.TestCase):
             self.assertEquals(activity_rows[0].action, u'on')
             self.assertEquals(activity_rows[0].old_value, u'')
             self.assertEquals(activity_rows[0].new_value,
-                              u'ValueError: Power script /usr/lib/python2.6/site-packages/bk')
+                              u'ValueError: Power script /usr/lib/python2.7/site-packages/bk')
             self.assertEquals(activity_rows[2].id, 3)
             self.assertEquals(activity_rows[2].user_id, 1)
             self.assertEquals(activity_rows[2].created,

--- a/LabController/setup.py
+++ b/LabController/setup.py
@@ -77,7 +77,7 @@ setup(
     classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Operating System :: POSIX :: Linux',
-        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
     ],
 

--- a/Misc/pylint-errors.cfg
+++ b/Misc/pylint-errors.cfg
@@ -1,7 +1,7 @@
 [MASTER]
 # The __requires__/import pkg_resources dance doesn't work here, since pylint
 # already imports pkg_resources while starting up
-init-hook='import sys; sys.path[0:0] =["/usr/lib/python2.6/site-packages/CherryPy-2.3.0-py2.6.egg/", "/usr/lib/python2.7/site-packages/CherryPy-2.3.0-py2.7.egg/"]'
+init-hook='import sys; sys.path[0:0] =["/usr/lib/python2.7/site-packages/CherryPy-2.3.0-py2.7.egg/"]'
 
 [MESSAGES CONTROL]
 disable=I,R,C,E0012

--- a/documentation/admin-guide/kickstarts.rst
+++ b/documentation/admin-guide/kickstarts.rst
@@ -193,7 +193,7 @@ order:
 
 - :file:`/etc/beaker/snippets/{snippet_name}`
 
-- :file:`/usr/lib/python2.6/site-packages/bkr/server/snippets/{snippet_name}`
+- :file:`/usr/lib/python2.7/site-packages/bkr/server/snippets/{snippet_name}`
 
 This allows administrators to customize Beaker kickstarts at whatever
 level is necessary.

--- a/documentation/admin-guide/panic-detection.rst
+++ b/documentation/admin-guide/panic-detection.rst
@@ -11,7 +11,7 @@ failed with a fatal error.
 You can customize the regexp pattern for detecting kernel panics by setting 
 ``PANIC_REGEX`` in ``/etc/beaker/labcontroller.conf``. The default pattern that 
 ships with Beaker is defined in 
-``/usr/lib/python2.6/site-packages/bkr/labcontroller/default.conf``. The 
+``/usr/lib/python2.7/site-packages/bkr/labcontroller/default.conf``. The
 pattern uses :ref:`Python regular expression syntax <python:re-syntax>`.
 
 Install failure patterns are read from a directory (rather than using a single 
@@ -20,7 +20,7 @@ checked against the console log. If any pattern matches, the installation is
 considered to have failed.
 
 Beaker ships a number of default patterns in the 
-``/usr/lib/python2.6/site-packages/bkr/labcontroller/install-failure-patterns/`` 
+``/usr/lib/python2.7/site-packages/bkr/labcontroller/install-failure-patterns/``
 directory. You can define extra custom patterns by placing them in 
 ``/etc/beaker/install-failure-patterns/``. A custom pattern overrides a default 
 pattern with the same filename. If a pattern is empty, Beaker ignores it. If 

--- a/documentation/admin-guide/power-commands.rst
+++ b/documentation/admin-guide/power-commands.rst
@@ -13,7 +13,7 @@ directories are searched on the lab controller, in order:
 
    Custom power scripts may be placed here.
 
--  ``/usr/lib/python2.6/site-packages/bkr/labcontroller/power-scripts``
+-  ``/usr/lib/python2.7/site-packages/bkr/labcontroller/power-scripts``
 
    These templates are packaged with Beaker and should not be modified.
 


### PR DESCRIPTION
Python 2.6 is no longer supported. Our codebase is compatible only with
Python 2.7. In some cases it can be sixed to Python 3.

Signed-off-by: Martin Styk <mastyk@redhat.com>