### PR TITLE
Kerberos is dead, long live the GSSAPI

### DIFF
--- a/Server/apache/beaker-server.conf
+++ b/Server/apache/beaker-server.conf
@@ -54,17 +54,14 @@ WSGIScriptAlias /bkr/ /usr/share/bkr/beaker-server.wsgi/bkr/
     ExpiresDefault "access plus 1 year"
 </Directory>
 
-# Authentication settings for kerberos logins..
+# Authentication settings for GSSAPI logins.
 # Uncomment and customize for your environment
 #<Location /bkr/login>
-#    AuthType Kerberos
-#    AuthName "Inventory Web UI"
-#    KrbMethodNegotiate on
-#    KrbMethodK5Passwd on
-#    KrbServiceName HTTP
-#    KrbAuthRealm DOMAIN.COM
-#    Krb5Keytab /etc/httpd/conf/httpd.keytab
-#    KrbSaveCredentials on
+#    AuthType GSSAPI
+#    AuthName "Beaker Auth"
+#    GssapiCredStore keytab:/etc/httpd/conf/httpd.keytab
+#    GssapiSSLonly On
+#    GssapiBasicAuth On ; fallback to BasicAuth
 #    Require valid-user
 #</Location>
 


### PR DESCRIPTION
As we are running on top of RHEL 7 we can use mods for GSSAPI rather than using mod_kerberos.
We were struggling with security and compatibility issues with Kerberos.

We should spread this wisdom to default configs as well.
Signed-off-by: Martin Styk <mastyk@redhat.com>