### PR TITLE
Add ability to control skip_if_unavailable for task repo

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/AtomicHost-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/AtomicHost-defaults.expected
@@ -282,6 +282,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 cp /etc/yum.repos.d/beaker-tasks.repo /root/
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained-custom.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained-custom.expected
@@ -292,6 +292,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 cp /etc/yum.repos.d/beaker-tasks.repo /root/
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained.expected
@@ -301,6 +301,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 cp /etc/yum.repos.d/beaker-tasks.repo /root/
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-scheduler-defaults.expected
@@ -267,6 +267,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedorarawhide-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedorarawhide-scheduler-defaults.expected
@@ -266,6 +266,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RHVH-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RHVH-defaults.expected
@@ -260,6 +260,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults-beaker-create-kickstart.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults-beaker-create-kickstart.expected
@@ -267,6 +267,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults.expected
@@ -267,6 +267,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-guest.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-guest.expected
@@ -254,6 +254,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-manual.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-manual.expected
@@ -222,6 +222,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-defaults.expected
@@ -266,6 +266,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-manual.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-manual.expected
@@ -223,6 +223,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxAlternateArchitectures7-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxAlternateArchitectures7-scheduler-defaults.expected
@@ -266,6 +266,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxServer5-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxServer5-scheduler-defaults.expected
@@ -255,6 +255,7 @@ name=beaker-tasks
 baseurl=@REPOS@@RECIPEID@
 enabled=1
 gpgcheck=0
+skip_if_unavailable=0
 EOF
 
 

--- a/Server/bkr/server/snippets/taskrepo
+++ b/Server/bkr/server/snippets/taskrepo
@@ -5,4 +5,5 @@ name={{ reponame }}
 baseurl={{ repourl }}
 enabled=1
 gpgcheck=0
+skip_if_unavailable={{ skip_taskrepo|default(0) }}
 EOF

--- a/documentation/user-guide/customizing-installation.rst
+++ b/documentation/user-guide/customizing-installation.rst
@@ -423,6 +423,10 @@ For example in the job XML::
     Do not configure X on the installed system. This is needed for headless 
     systems which lack graphics support.
 
+``skip_taskrepo``
+    Configure ``skip_if_unavailable`` yum repo attribute for task repository.
+    Default value is 0.
+
 ``static_networks=<device>,<ipv4_address>[;...]``
     Configure one or more network devices to start on boot with static IPv4 
     addresses. The device should be given as a kernel device name (for example, 


### PR DESCRIPTION
User can control skip_if_unavailable via ks_meta.

Fixes: #58 