### PR TITLE
Allow user to define whole kickstart for jobs

### DIFF
--- a/Server/bkr/server/kickstart.py
+++ b/Server/bkr/server/kickstart.py
@@ -237,8 +237,14 @@ def kickstart_template(osmajor):
                      % (osmajor, ', '.join(candidates)))
 
 
-def generate_kickstart(install_options, distro_tree, system, user,
-                       recipe=None, ks_appends=None, kickstart=None, installation=None):
+def generate_kickstart(install_options,
+                       distro_tree,
+                       system, user,
+                       recipe=None,
+                       ks_appends=None,
+                       kickstart=None,
+                       installation=None,
+                       no_template=None):
     if recipe:
         lab_controller = recipe.recipeset.lab_controller
     elif system:
@@ -329,8 +335,9 @@ def generate_kickstart(install_options, distro_tree, system, user,
 
     with TemplateRenderingEnvironment():
         if kickstart:
-            template = template_env.from_string(
-                "{% snippet 'install_method' %}\n" + kickstart)
+            template_string = ("{% snippet 'install_method' %}\n" + kickstart
+                               if not no_template else kickstart)
+            template = template_env.from_string(template_string)
             result = template.render(restricted_context)
         else:
             template = kickstart_template(installation.osmajor)

--- a/documentation/user-guide/customizing-installation.rst
+++ b/documentation/user-guide/customizing-installation.rst
@@ -336,6 +336,11 @@ For example in the job XML::
     variable if you want to supply explicit partitioning commands in some other
     way, for example in a ``<ks_append/>`` section.
 
+``no_ks_template``
+    The whole kickstart has to be defined by user in ``<kickstart />`` tag.
+    Default Beaker's templating is not used; however, user does have
+    access to snippets and restricted context.
+
 ``no_networks``
     Omits the ``network`` command. By default when no specific network is
     requested for a recipe, the kickstart will include


### PR DESCRIPTION
Some teams would like to have more flexibility about `<kickstart />`.
The problem is that we still defining minimum content for them.

With this patch, it is completely up to the user how kickstart will look like even within `job` and it is their responsibility to make sure that they will be operational.

Bug: [1831885](https://bugzilla.redhat.com/show_bug.cgi?id=1831885)
Signed-off-by: Martin Styk <mastyk@redhat.com>