### PR TITLE
Use USERNAME from config

### DIFF
--- a/Client/src/bkr/client/__init__.py
+++ b/Client/src/bkr/client/__init__.py
@@ -81,6 +81,8 @@ class BeakerCommand(Command):
         if kwargs.get('insecure'):
             self.conf['SSL_VERIFY'] = False
         proxy_user = kwargs.get('proxy_user')
+        if username is None and 'USERNAME' in self.conf:
+            username = self.conf['USERNAME']
         self.container.set_hub(username, password, auto_login=self.requires_login,
                                proxy_user=proxy_user)
 


### PR DESCRIPTION
It is possible to specify the USERNAME in the Beaker `config` file like:
```
USERNAME = "my_username"
```
...but the USERNAME is still not used by commands like:
```
$ bkr whoami
XML-RPC fault: <class 'bkr.server.authentication.LoginException'>:Invalid username or password
```
(or it's using the USERNAME, but not prompting for a password.)

If a USERNAME is specified in the `config` file, use it:
```
$ bkr whoami
Enter your password:
{"username": "my_username", "email_address": "my_email@my_domain"}
```

Signed-off-by: Paul A. Clarke <pc@us.ibm.com>