### PR TITLE
Remove kickstart install command from rawhide

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/AtomicHost-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/AtomicHost-defaults.expected
@@ -23,8 +23,6 @@ selinux --disabled
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedorarawhide-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedorarawhide-scheduler-defaults.expected
@@ -25,8 +25,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/Server/bkr/server/kickstarts/default
+++ b/Server/bkr/server/kickstarts/default
@@ -60,8 +60,6 @@ skipx
 {% endif %}
 
 {% snippet 'timezone' %}
-# Install OS instead of upgrade
-install
 
 {% snippet 'rhts_devices' %}
 {% snippet 'rhts_partitions' %}


### PR DESCRIPTION
The kickstart 'install' command has been deprecated since Fedora 29 and
is being removed in Fedora 34. See:

https://github.com/pykickstart/pykickstart/pull/347