### PR TITLE
fix: base64.encodestring() doesn't exist in Python 3.9

### DIFF
--- a/Common/bkr/common/hub.py
+++ b/Common/bkr/common/hub.py
@@ -203,7 +203,10 @@ class HubProxy(object):
                 ex.message += ". Make sure you correctly set KRB_REALM (current value: %s)." % realm
                 ex.args = (ex.message, )
             raise ex
-        req_enc = base64.encodestring(res.token)
+        if six.PY2:
+            req_enc = base64.encodestring(res.token)
+        else:
+            req_enc = base64.encodebytes(res.token)
         try:
             req_enc = str(req_enc, 'utf-8')  # bytes to string
         except TypeError:


### PR DESCRIPTION
Python 3.9 has removed the deprecated method 'encodestring' from base64 module.
It needs to be replaced by ' encodebytes'.

Signed-off-by: Xavi Hernandez <xhernandez@redhat.com>