### PR TITLE
Remove install kickstart command 

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/AtomicHost-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/AtomicHost-defaults.expected
@@ -23,8 +23,6 @@ selinux --disabled
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained-custom.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained-custom.expected
@@ -26,8 +26,6 @@ selinux --disabled
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-harness-contained.expected
@@ -27,8 +27,6 @@ selinux --disabled
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedora18-scheduler-defaults.expected
@@ -26,8 +26,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedorarawhide-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/Fedorarawhide-scheduler-defaults.expected
@@ -25,8 +25,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RHVH-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RHVH-defaults.expected
@@ -22,8 +22,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-manual-defaults-beaker-create-kickstart.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-manual-defaults-beaker-create-kickstart.expected
@@ -32,8 +32,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-manual-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-manual-defaults.expected
@@ -32,8 +32,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults-beaker-create-kickstart.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults-beaker-create-kickstart.expected
@@ -32,8 +32,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-defaults.expected
@@ -32,8 +32,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-guest.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux6-scheduler-guest.expected
@@ -32,8 +32,6 @@ selinux --enforcing
 
 # System timezone
 timezone --utc America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinux7-scheduler-defaults.expected
@@ -28,8 +28,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxAlternateArchitectures7-scheduler-defaults.expected
+++ b/IntegrationTests/src/bkr/inttest/server/kickstarts/RedHatEnterpriseLinuxAlternateArchitectures7-scheduler-defaults.expected
@@ -28,8 +28,6 @@ selinux --enforcing
 
 # System timezone
 timezone America/New_York
-# Install OS instead of upgrade
-install
 
 zerombr
 clearpart --all --initlabel

--- a/Server/bkr/server/kickstarts/default
+++ b/Server/bkr/server/kickstarts/default
@@ -60,8 +60,6 @@ skipx
 {% endif %}
 
 {% snippet 'timezone' %}
-# Install OS instead of upgrade
-install
 
 {% snippet 'rhts_devices' %}
 {% snippet 'rhts_partitions' %}


### PR DESCRIPTION
The kickstart 'install' command has been deprecated since Fedora 29 and
is being removed in Fedora 34.
ref: pykickstart/pykickstart#347.

Instead of removing it only for Fedora, we will drop it for RHEL as well as this is completely fine.