### PR TITLE
Silence no-member pylint error for Python 3 encodebytes

### DIFF
--- a/Common/bkr/common/hub.py
+++ b/Common/bkr/common/hub.py
@@ -206,7 +206,7 @@ class HubProxy(object):
         if six.PY2:
             req_enc = base64.encodestring(res.token)
         else:
-            req_enc = base64.encodebytes(res.token)
+            req_enc = base64.encodebytes(res.token)  # pylint: disable=maybe-no-member
         try:
             req_enc = str(req_enc, 'utf-8')  # bytes to string
         except TypeError:


### PR DESCRIPTION
We introduced an error in #75 
We need to silence it otherwise it will bother us in all reviews.