### PR TITLE
Fix: Get console logs raises Exception

### DIFF
--- a/LabController/src/bkr/labcontroller/utils.py
+++ b/LabController/src/bkr/labcontroller/utils.py
@@ -74,6 +74,10 @@ def get_console_files(console_logs_directory, system_name):
                     console_logs_directory)
         return []
 
+    if not system_name:
+        logger.info("No System Name for console log file...Ignoring")
+        return []
+
     output = []
     for filename in sorted(os.listdir(console_logs_directory)):
         if filename.startswith(system_name):


### PR DESCRIPTION
When a guest recipe console log was being processed during beaker
upgrade, an exception was raised with call to startswith in
labcontroller.utils.get_console_files.  In the case of guest recipes,
it is possible for the system name to be None. This change recognizes
this case, reports this occurred, and discontinues getting console
files for this guest recipes.  Since exception is not raised, other recipes
will continue to get their console files.

Closes: BKR-5038