### PR TITLE
Fix: 500 internal error returned for some users

### DIFF
--- a/IntegrationTests/src/bkr/inttest/ldap-data.ldif
+++ b/IntegrationTests/src/bkr/inttest/ldap-data.ldif
@@ -104,6 +104,20 @@ gidNumber: 15554
 homeDirectory: /home/lol
 mail: another_my_ldap_user@example.invalid
 
+dn: uid=retired_ldap_user,ou=users,dc=example,dc=invalid
+objectClass: top
+objectClass: person
+objectClass: organizationalperson
+objectClass: inetorgperson
+objectClass: posixAccount
+cn: Retired My LDAP User
+givenName: Retired
+sn: Retired My LDAP User
+uid: retired_ldap_user
+uidNumber: 15555
+gidNumber: 15555
+homeDirectory: /home/BKR-5058
+
 dn: cn=my_ldap_group,ou=groups,dc=example,dc=invalid
 objectClass: top
 objectClass: posixGroup

--- a/IntegrationTests/src/bkr/inttest/server/selenium/test_users.py
+++ b/IntegrationTests/src/bkr/inttest/server/selenium/test_users.py
@@ -226,6 +226,16 @@ class UserHTTPTest(DatabaseTestCase):
         self.assertEqual(response.json()['proxied_by_user']['user_name'],
                          proxying_user.user_name)
 
+    def test_get_ldap_user(self):
+        user = User.by_user_name(u'my_ldap_user')
+        self.assertEqual(user.user_name, 'my_ldap_user')
+        self.assertEqual(user.display_name, 'My LDAP User')
+        self.assertEqual(user.email_address, 'my_ldap_user@example.invalid')
+
+    def test_get_retired_ldap_user(self):
+        user = User.by_user_name(u'retired_ldap_user')
+        self.assertIsNone(user)
+
     def test_create_user(self):
         s = requests.Session()
         requests_login(s)

--- a/Server/bkr/server/model/identity.py
+++ b/Server/bkr/server/model/identity.py
@@ -295,6 +295,8 @@ class User(DeclarativeMappedObject, ActivityMixin):
             # who doesn't actually match the username we were given.
             if attrs['uid'][0].decode('utf8') != user_name:
                 return None
+            if 'mail' not in attrs:
+                return None
             user = User()
             user.user_name = attrs['uid'][0].decode('utf8')
             user.display_name = attrs['cn'][0].decode('utf8')


### PR DESCRIPTION
When getting users from beaker by way of
https:/beaker.com/users/username and that user is retired from company,
seeing a "500 internal error" instead of "Not Found" error.  The
failure is in get user LDAP look-up since an exception is raised when
looking for the "mail" key entry that no longer exists. Code
now checks whether it is present. If not, None returned for user.

Closes: BKR-5058