### PR TITLE
Fix deprecated kernel options for newer distros

### DIFF
--- a/IntegrationTests/src/bkr/inttest/labcontroller/test_proxy.py
+++ b/IntegrationTests/src/bkr/inttest/labcontroller/test_proxy.py
@@ -1328,7 +1328,8 @@ class GetInstallationForSystemTest(LabControllerTestCase):
         self.assertEqual(installinfo['initrd_url'],
                 u'http://example.invalid/installationforsystem/pxeboot/initrd')
         self.assertEqual(installinfo['kernel_options'],
-                'ks=%s netbootloader=pxelinux.0 noverifyssl' % self.recipe.installation.rendered_kickstart.link)
+                         'inst.ks=%s netbootloader=pxelinux.0 noverifyssl'
+                         % self.recipe.installation.rendered_kickstart.link)
 
 
 class HealthTest(LabControllerTestCase):

--- a/IntegrationTests/src/bkr/inttest/server/selenium/test_systems.py
+++ b/IntegrationTests/src/bkr/inttest/server/selenium/test_systems.py
@@ -446,10 +446,10 @@ class IpxeScriptHTTPTest(DatabaseTestCase):
                 'systems/by-uuid/%s/ipxe-script' % recipe.resource.instance_id)
         response.raise_for_status()
         self.assertMultiLineEqual(response.text, """#!ipxe
-kernel http://mydistro.dummylab.test/os/pxeboot/vmlinuz console=tty0 console=ttyS0,115200n8 ks=%s noverifyssl netboot_method=ipxe
+kernel http://mydistro.dummylab.test/os/pxeboot/vmlinuz console=tty0 console=ttyS0,115200n8 inst.ks=%s noverifyssl netboot_method=ipxe
 initrd http://mydistro.dummylab.test/os/pxeboot/initrd
 boot
-""" % recipe.installation.rendered_kickstart.link)
+""" % recipe.installation.rendered_kickstart.link)  # noqa: E501
 
     def test_recipe_provision_with_custom_distro_and_incompatible_url(self):
         with session.begin():
@@ -481,10 +481,10 @@ boot
                 'systems/by-uuid/%s/ipxe-script' % recipe.resource.instance_id)
         response.raise_for_status()
         self.assertEquals(response.text, """#!ipxe
-kernel http://example.com/ipxe-test/F20/x86_64/os/pxeboot/vmlinuz console=tty0 console=ttyS0,115200n8 ks=%s noverifyssl netboot_method=ipxe
+kernel http://example.com/ipxe-test/F20/x86_64/os/pxeboot/vmlinuz console=tty0 console=ttyS0,115200n8 ks=%s ksdevice=bootif noverifyssl netboot_method=ipxe
 initrd http://example.com/ipxe-test/F20/x86_64/os/pxeboot/initrd
 boot
-""" % recipe.installation.rendered_kickstart.link)
+""" % recipe.installation.rendered_kickstart.link)  # noqa: E501
 
 class SystemHTTPTest(DatabaseTestCase):
     """

--- a/IntegrationTests/src/bkr/inttest/server/test_model.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_model.py
@@ -1400,6 +1400,27 @@ class DistroTreeTest(DatabaseTestCase):
         self.assertIn('preseed/url=http://', r1.installation.kernel_options)
         self.assertNotIn('ks=', r1.installation.kernel_options)
 
+    def test_ks_option_for_older_systems(self):
+        distro_tree = data_setup.create_distro_tree(osmajor=u'CentOS7')
+        recipe = self.provision_distro_tree(distro_tree)
+        self.assertIn('ks=', recipe.installation.kernel_options)
+        self.assertNotIn('inst.ks=', recipe.installation.kernel_options)
+
+    def test_inst_ks_option_for_newer_systems(self):
+        distro_tree = data_setup.create_distro_tree(osmajor=u'Fedora34')
+        recipe = self.provision_distro_tree(distro_tree)
+        self.assertIn('inst.ks=', recipe.installation.kernel_options)
+        self.assertFalse(re.search(r"(?<!inst\.)ks=", recipe.installation.kernel_options))
+
+    def test_ksdevice_option_for_older_systems(self):
+        distro_tree = data_setup.create_distro_tree(osmajor=u'CentOS7')
+        recipe = self.provision_distro_tree(distro_tree)
+        self.assertIn('ksdevice=bootif', recipe.installation.kernel_options)
+
+    def test_no_ksdevice_option_for_newer_systems(self):
+        distro_tree = data_setup.create_distro_tree(osmajor=u'Fedora34')
+        recipe = self.provision_distro_tree(distro_tree)
+        self.assertNotIn('ksdevice', recipe.installation.kernel_options)
 
     def test_custom_netbootloader(self):
 
@@ -1464,6 +1485,11 @@ class DistroTreeTest(DatabaseTestCase):
     # https://bugzilla.redhat.com/show_bug.cgi?id=1172472
     def test_leavebootorder_kernel_option_is_set_by_default_for_ppc(self):
         distro_tree = data_setup.create_distro_tree(arch=u'ppc64')
+        recipe = self.provision_distro_tree(distro_tree)
+        self.assertIn(u'inst.leavebootorder', recipe.installation.kernel_options.split())
+
+    def test_leavebootorder_kernel_option_has_no_prefix_for_older_distro(self):
+        distro_tree = data_setup.create_distro_tree(osmajor=u'CentOS7', arch=u'ppc64')
         recipe = self.provision_distro_tree(distro_tree)
         self.assertIn(u'leavebootorder', recipe.installation.kernel_options.split())
 

--- a/Server/bkr/server/installopts.py
+++ b/Server/bkr/server/installopts.py
@@ -119,5 +119,5 @@ class InstallOptions(object):
 def global_install_options():
     return InstallOptions.from_strings(
             config.get('beaker.ks_meta', u''),
-            config.get('beaker.kernel_options', u'ksdevice=bootif'),
+            config.get('beaker.kernel_options', u''),
             config.get('beaker.kernel_options_post', u''))

--- a/Server/bkr/server/model/distrolibrary.py
+++ b/Server/bkr/server/model/distrolibrary.py
@@ -178,7 +178,17 @@ def default_install_options_for_distro(osmajor_name, osminor, variant, arch):
     # for s390, s390x and armhfp, we default to ''
     kernel_options['netbootloader'] = netbootloader.get(arch.arch, '')
     if arch.arch in ['ppc', 'ppc64', 'ppc64le']:
-        kernel_options['leavebootorder'] = None
+        if rhel and int(rhel) < 9 or \
+                (fedora and fedora != 'rawhide' and int(fedora) < 34):
+            kernel_options['leavebootorder'] = None
+        else:
+            kernel_options['inst.leavebootorder'] = None
+
+    # Keep old kernel options for older distros
+    if rhel and int(rhel) < 9 or \
+            (fedora and fedora != 'rawhide' and int(fedora) < 34):
+        kernel_options['ksdevice'] = 'bootif'
+        ks_meta['ks_keyword'] = 'ks'
 
     return InstallOptions(ks_meta, kernel_options, {})
 

--- a/Server/bkr/server/model/inventory.py
+++ b/Server/bkr/server/model/inventory.py
@@ -1546,13 +1546,15 @@ class System(DeclarativeMappedObject, ActivityMixin):
                             self.reprovision_distro_tree)
                     installation = self.reprovision_distro_tree.create_installation_from_tree()
                     installation.tree_url = self.reprovision_distro_tree.url_in_lab(lab_controller=self.lab_controller)
-                    if 'ks' not in install_options.kernel_options:
+
+                    ks_keyword = install_options.ks_meta.get('ks_keyword', 'inst.ks')
+                    if ks_keyword not in install_options.kernel_options:
                         rendered_kickstart = generate_kickstart(
                             install_options=install_options,
                             installation=installation,
                             distro_tree=self.reprovision_distro_tree,
                             system=self, user=self.owner)
-                        install_options.kernel_options['ks'] = rendered_kickstart.link
+                        install_options.kernel_options[ks_keyword] = rendered_kickstart.link
                     else:
                         rendered_kickstart = None
                     by_kernel = ImageType.uimage if self.kernel_type and self.kernel_type.uboot \

--- a/Server/bkr/server/model/scheduler.py
+++ b/Server/bkr/server/model/scheduler.py
@@ -2647,7 +2647,7 @@ class Recipe(TaskBase, ActivityMixin):
             if 'no_default_harness_repo' not in install_options.ks_meta \
                     and not self.harness_repo():
                 raise ValueError('Failed to find repo for harness')
-        ks_keyword = install_options.ks_meta.get('ks_keyword', 'ks')
+        ks_keyword = install_options.ks_meta.get('ks_keyword', 'inst.ks')
         # Use only user input for kickstart
         no_ks_template = 'no_ks_template' in install_options.ks_meta
         ks_appends = None

--- a/Server/bkr/server/systems.py
+++ b/Server/bkr/server/systems.py
@@ -225,13 +225,15 @@ class SystemsController(controllers.Controller):
             kernel_options_post or ''))
         installation = distro_tree.create_installation_from_tree()
         installation.tree_url = distro_tree.url_in_lab(lab_controller=system.lab_controller)
-        if 'ks' not in options.kernel_options:
+
+        ks_keyword = options.ks_meta.get('ks_keyword', 'inst.ks')
+        if ks_keyword not in options.kernel_options:
             rendered_kickstart = generate_kickstart(
                 install_options=options,
                 installation=installation,
                 distro_tree=distro_tree,
                 system=system, user=identity.current.user, kickstart=kickstart)
-            options.kernel_options['ks'] = rendered_kickstart.link
+            options.kernel_options[ks_keyword] = rendered_kickstart.link
         else:
             rendered_kickstart = None
         by_kernel = ImageType.uimage if system.kernel_type and system.kernel_type.uboot \
@@ -1215,11 +1217,12 @@ def provision_system(fqdn):
         installation.tree_url = distro_tree.url_in_lab(lab_controller=system.lab_controller)
         installation.system = system
 
-        if 'ks' not in install_options.kernel_options:
+        ks_keyword = install_options.ks_meta.get('ks_keyword', 'inst.ks')
+        if ks_keyword not in install_options.kernel_options:
             kickstart = generate_kickstart(install_options=install_options,
                                            distro_tree=distro_tree, system=system, user=user,
                                            installation=installation)
-            install_options.kernel_options['ks'] = kickstart.link
+            install_options.kernel_options[ks_keyword] = kickstart.link
         else:
             kickstart = None
         by_kernel = ImageType.uimage if system.kernel_type and system.kernel_type.uboot \

--- a/Server/server.cfg
+++ b/Server/server.cfg
@@ -105,7 +105,7 @@ sqlalchemy.pool_recycle = 3600
 # These install options are used as global defaults for every provision. They
 # can be overriden by options on the distro tree, the system, or the recipe.
 #beaker.ks_meta = ""
-#beaker.kernel_options = "ksdevice=bootif"
+#beaker.kernel_options = ""
 #beaker.kernel_options_post = ""
 
 # When generating MAC addresses for virtual systems, Beaker will always pick


### PR DESCRIPTION
This fixes #83.

Changed it for RHEL9+ and Fedora34+