### PR TITLE
Add support for Fedora 34

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -20,5 +20,6 @@ jobs:
       - epel-8-x86_64
       - fedora-32-x86_64
       - fedora-33-x86_64
+      - fedora-34-x86_64
       - fedora-rawhide-x86_64
       - centos-stream-x86_64


### PR DESCRIPTION
Fedora 34 branched out, therefore we need to add new target.
Rawhide is baseline for Fedora 35 now.

Signed-off-by: Martin Styk <mart.styk@gmail.com>