### PR TITLE
Make Beaker operational again

### DIFF
--- a/Server/bkr/server/activity.py
+++ b/Server/bkr/server/activity.py
@@ -90,11 +90,9 @@ def get_distro_activity():
     distro_columns = {
         'distro': Distro.name,
         'distro.name': Distro.name,
-    }
+    }.update(common_activity_search_columns)
     json_result = json_collection(query,
-                                  columns={
-                                      **common_activity_search_columns,
-                                      **distro_columns},
+                                  columns=distro_columns,
                                   skip_count=True)
     return jsonify(json_result)
 
@@ -132,11 +130,9 @@ def get_distro_tree_activity():
         'distro_tree.distro.name': Distro.name,
         'distro_tree.variant': DistroTree.variant,
         'distro_tree.arch': Arch.arch,
-    }
+    }.update(common_activity_search_columns)
     json_result = json_collection(query,
-                                  columns={
-                                      **common_activity_search_columns,
-                                      **distro_tree_columns},
+                                  columns=distro_tree_columns,
                                   skip_count=True)
     return jsonify(json_result)
 
@@ -165,12 +161,9 @@ def get_group_activity():
     group_columns = {
         'group': Group.group_name,
         'group.group_name': Group.group_name,
-    }
+    }.update(common_activity_search_columns)
     json_result = json_collection(query,
-                                  columns={
-                                      **common_activity_search_columns,
-                                      **group_columns
-                                  })
+                                  columns=group_columns)
     return jsonify(json_result)
 
 @app.route('/activity/labcontroller', methods=['GET'])
@@ -197,12 +190,9 @@ def get_lab_controller_activity():
     lc_columns = {
         'lab_controller': LabController.fqdn,
         'lab_controller.fqdn': LabController.fqdn,
-    }
+    }.update(common_activity_search_columns)
     json_result = json_collection(query,
-                                  columns={
-                                      **common_activity_search_columns,
-                                      **lc_columns
-                                  })
+                                  columns=lc_columns)
     return jsonify(json_result)
 
 
@@ -230,12 +220,9 @@ def get_systems_activity(): # distinct from get_system_activity
     system_columns = {
         'system': System.fqdn,
         'system.fqdn': System.fqdn,
-    }
+    }.update(common_activity_search_columns)
     json_result = json_collection(query,
-                                  columns={
-                                      **common_activity_search_columns,
-                                      **system_columns
-                                  },
+                                  columns=system_columns,
                                   skip_count=True)
     return jsonify(json_result)
 
@@ -270,10 +257,8 @@ def get_system_pools_activity():
         'pool.name': SystemPool.name,
         'pool.owner.user_name': User.user_name,
         'pool.owner.group_name': Group.group_name,
-    }
+    }.update(common_activity_search_columns)
     json_result = json_collection(query,
-                                  columns={
-                                      **common_activity_search_columns,
-                                      **pool_columns},
+                                  columns=pool_columns,
                                   skip_count=True)
     return jsonify(json_result)

--- a/Server/bkr/server/authentication.py
+++ b/Server/bkr/server/authentication.py
@@ -10,7 +10,7 @@ from flask import request
 
 from bkr.server import identity
 from bkr.server.app import app
-from bkr.server.flask_util import auth_required, read_json_request, Unauthorised401
+from bkr.server.flask_util import auth_required, read_json_request, Unauthorised401, UnsupportedMediaType415
 from bkr.server.model import User
 
 log = logging.getLogger(__name__)
@@ -32,8 +32,11 @@ def login_password():
 
     """
 
-    payload = read_json_request(request)
-    proxy_user = payload.get("proxy_user")
+    try:
+        payload = read_json_request(request)
+        proxy_user = payload.get("proxy_user")
+    except UnsupportedMediaType415:
+        proxy_user = None
 
     if not request.authorization:
         raise Unauthorised401("Authorization header is missing")

--- a/Server/bkr/server/controllers.py
+++ b/Server/bkr/server/controllers.py
@@ -31,7 +31,6 @@ import bkr.server.stdvars
 from bkr.server import metrics, identity
 from bkr.server.CSV_import_export import CSV
 from bkr.server.app import app
-from bkr.server.authentication import Auth
 from bkr.server.bexceptions import BX
 from bkr.server.bexceptions import DatabaseLookupError
 from bkr.server.cherrypy_util import PlainTextHTTPException
@@ -160,7 +159,6 @@ class Root(RPCRoot):
     distrotrees = DistroTrees()
     users = Users()
     arches = Arches()
-    auth = Auth()
     csv = CSV()
     jobs = Jobs()
     recipesets = RecipeSets()


### PR DESCRIPTION
Few minor things that blocked me to use Beaker from develop properly.
- BasicAuth doesn't require proxy users anymore to work as intended
- Auth removed from root controller as we don't have XMLRPC there anymore
- Python 6 implementation for Activities 
