### PR TITLE
Extend CI targets

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,4 +23,4 @@ jobs:
       - fedora-35-x86_64
       - fedora-rawhide-x86_64
       - centos-stream-8-x86_64
-      - centos-stream-9-x86_64
+      # - centos-stream-9-x86_64 - Broken dependencies at this moment

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,8 +18,9 @@ jobs:
   metadata:
     targets:
       - epel-8-x86_64
-      - fedora-32-x86_64
       - fedora-33-x86_64
       - fedora-34-x86_64
+      - fedora-35-x86_64
       - fedora-rawhide-x86_64
-      - centos-stream-x86_64
+      - centos-stream-8-x86_64
+      - centos-stream-9-x86_64


### PR DESCRIPTION
- Fedora 32 is dead
- Fedora 35 is branched and can be used
- CentOS Stream 8 got renamed to avoid confusion from CentOS Stream 9
- CentOS Stream 9 added. This is completely new pre-release target

Signed-off-by: Martin Styk <mart.styk@gmail.com>