### PR TITLE
Fix: onerror is not supported on <=rhel7.3

### DIFF
--- a/Server/bkr/server/model/distrolibrary.py
+++ b/Server/bkr/server/model/distrolibrary.py
@@ -114,7 +114,7 @@ def default_install_options_for_distro(osmajor_name, osminor, variant, arch):
         del ks_meta['has_unsupported_hardware']
     # support for %onerror
     ks_meta['has_onerror'] = True
-    if rhel in ('5', '6'):
+    if rhel in ('5', '6') or (rhel == '7' and int(osminor) <= 3):
         del ks_meta['has_onerror']
 
     # mode


### PR DESCRIPTION
Installs of RHEL 7 up to 7.3 (including) are failing when anaconda could not recognize `%onerror` section. We should not mark those builds with `has_onerror`.

Feature was introduced here: [RHEL 7.4 release notes](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/7.4_release_notes/new_features_installation_and_booting#BZ1412538)