### PR TITLE
[git] modules: use https instead of git

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "bootstrap"]
 	path = Server/assets/bootstrap
-	url = git://github.com/twbs/bootstrap.git
+	url = https://github.com/twbs/bootstrap.git
 [submodule "font-awesome"]
 	path = Server/assets/font-awesome
-	url = git://github.com/FortAwesome/Font-Awesome.git
+	url = https://github.com/FortAwesome/Font-Awesome.git
 [submodule "typeahead.js"]
 	path = Server/assets/typeahead.js
 	url = https://github.com/twitter/typeahead.js.git


### PR DESCRIPTION
Unencrypted git protocol become obsolete and prohibited by some systems [0]. Some of our projects are dependent on `beaker-client` and `beaker-common`. However, pipenv locking fails due to old git protocol. This pull request contains fixed protocol in submodules.

I am opening PR into master to include the fix ASAP. If you have a different development workflow and it violates your plans, feel free to move it into `develop` branch.

[0] https://github.blog/2021-09-01-improving-git-protocol-security-github/