### PR TITLE
Enable build on CentOS Stream 9

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,4 +23,4 @@ jobs:
       - fedora-35-x86_64
       - fedora-rawhide-x86_64
       - centos-stream-8-x86_64
-      - centos-stream-9-x86_64
+      # - centos-stream-9-x86_64 - Broken dependencies at this moment

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -23,4 +23,4 @@ jobs:
       - fedora-35-x86_64
       - fedora-rawhide-x86_64
       - centos-stream-8-x86_64
-      # - centos-stream-9-x86_64 - Broken dependencies at this moment
+      - centos-stream-9-x86_64

--- a/.packit.yaml
+++ b/.packit.yaml
@@ -18,8 +18,9 @@ jobs:
   metadata:
     targets:
       - epel-8-x86_64
-      - fedora-31-x86_64
-      - fedora-32-x86_64
       - fedora-33-x86_64
+      - fedora-34-x86_64
+      - fedora-35-x86_64
       - fedora-rawhide-x86_64
-      - centos-stream-x86_64
+      - centos-stream-8-x86_64
+      - centos-stream-9-x86_64

--- a/Client/run-tests.sh
+++ b/Client/run-tests.sh
@@ -4,12 +4,12 @@ set -x
 
 # Use Python 2 version if BKR_PY3 is not defined
 if [[ -z ${BKR_PY3} ]]; then
-    nose_command="nosetests";
+    pytest_command="py.test-2";
 elif [[ ${BKR_PY3} == 1 ]]; then
-    nose_command="nosetests-3";
+    pytest_command="pytest-3";
 else
-    nose_command="nosetests";
+    pytest_command="py.test-2";
 fi
 
 env PYTHONPATH=../Client/src:../Common${PYTHONPATH:+:$PYTHONPATH} \
-    $nose_command ${*:--v --traverse-namespace bkr.client.tests}
+    $pytest_command

--- a/Client/src/bkr/client/tests/test_wizard.py
+++ b/Client/src/bkr/client/tests/test_wizard.py
@@ -5,10 +5,14 @@
 
 import unittest
 from datetime import date
-from mock import Mock, patch
 from six.moves import StringIO
 
 from bkr.client import wizard
+
+try:
+    from unittest.mock import Mock, patch
+except ImportError:
+    from mock import Mock, patch
 
 EXPECTED_GPL_HEADER = ("Copyright (c) %s %s.\n" %
                        (date.today().year, wizard.LICENSE_ORGANISATION))

--- a/Common/run-tests.sh
+++ b/Common/run-tests.sh
@@ -1,15 +1,15 @@
-#/bin/bash
+#!/bin/bash
 
 set -x
 
 # Use Python 2 version if BKR_PY3 is not defined
 if [[ -z ${BKR_PY3} ]]; then
-    nose_command="nosetests";
+    pytest_command="py.test-2";
 elif [[ ${BKR_PY3} == 1 ]]; then
-    nose_command="nosetests-3";
+    pytest_command="pytest-3";
 else
-    nose_command="nosetests";
+    pytest_command="py.test-2";
 fi
 
-env PYTHONPATH=.${PYTHONPATH:+:$PYTHONPATH} \
-    $nose_command ${*:--v bkr}
+env PYTHONPATH=../Client/src:../Common${PYTHONPATH:+:$PYTHONPATH} \
+    $pytest_command

--- a/beaker.spec
+++ b/beaker.spec
@@ -49,8 +49,7 @@ BuildArch:      noarch
 BuildRequires:  make
 %if %{with python3}
 BuildRequires:  python3-setuptools
-BuildRequires:  python3-nose
-BuildRequires:  python3-mock
+BuildRequires:  python3-pytest
 BuildRequires:  python3-devel
 BuildRequires:  python3-docutils
 BuildRequires:  python3-sphinx


### PR DESCRIPTION
I cherry-picked commits from `develop` to align packit behavior.
Then I enable C9 and removed all obstacles.

This will be released under 28.5
Fixes #141 