### PR TITLE
Don't use None as a key

### DIFF
--- a/Server/bkr/server/distrotrees.py
+++ b/Server/bkr/server/distrotrees.py
@@ -228,9 +228,9 @@ gpgcheck=0
         Old URL will be replaced if new URL uses the same scheme
         """
         new_urls_by_scheme = dict(
-            (urlparse.urlparse(url, scheme=None).scheme, url) for url in urls)
-        if None in new_urls_by_scheme:
-            raise ValueError('URL %r is not absolute' % new_urls_by_scheme[None])
+            (urlparse.urlparse(url, scheme='invalid').scheme, url) for url in urls)
+        if 'invalid' in new_urls_by_scheme:
+            raise ValueError('URL %r is not absolute' % new_urls_by_scheme['invalid'])
         for lca in distro_tree.lab_controller_assocs:
             if lca.lab_controller == lab_controller:
                 scheme = urlparse.urlparse(lca.url).scheme


### PR DESCRIPTION
Using None as a default scheme is problematic with the newest python.
It will produce the following error:

>>> url = 'http://foo.example.com/RHEL-8.7/compose/BaseOS/x86_64/os/'
>>> urlparse.urlparse(url, scheme=None).scheme
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib64/python2.7/urlparse.py", line 145, in urlparse
    tuple = urlsplit(url, scheme, allow_fragments)
  File "/usr/lib64/python2.7/urlparse.py", line 201, in urlsplit
    scheme = _remove_unsafe_bytes_from_url(scheme)
  File "/usr/lib64/python2.7/urlparse.py", line 191, in _remove_unsafe_bytes_from_url
    url = url.replace(b, "")
AttributeError: 'NoneType' object has no attribute 'replace'