### PR TITLE
Fix changes for Enable CentOS Stream 9 build

### DIFF
--- a/Client/run-tests.sh
+++ b/Client/run-tests.sh
@@ -2,14 +2,11 @@
 
 set -x
 
-# Use Python 2 version if BKR_PY3 is not defined
-if [[ -z ${BKR_PY3} ]]; then
-    pytest_command="py.test-2";
-elif [[ ${BKR_PY3} == 1 ]]; then
-    pytest_command="pytest-3";
+# if BKR_PY3 is present and defined use pytest-3
+if [[ -z ${BKR_PY3} ]] || [[ ${BKR_PY3} != 1 ]]; then
+    test_command="nosetests ${*:--v --traverse-namespace bkr.client.tests}";
 else
-    pytest_command="py.test-2";
+    test_command="pytest-3";
 fi
 
-env PYTHONPATH=../Client/src:../Common${PYTHONPATH:+:$PYTHONPATH} \
-    $pytest_command
+env PYTHONPATH=../Client/src:../Common${PYTHONPATH:+:$PYTHONPATH} ${test_command}

--- a/Common/run-tests.sh
+++ b/Common/run-tests.sh
@@ -2,14 +2,12 @@
 
 set -x
 
-# Use Python 2 version if BKR_PY3 is not defined
-if [[ -z ${BKR_PY3} ]]; then
-    pytest_command="py.test-2";
-elif [[ ${BKR_PY3} == 1 ]]; then
-    pytest_command="pytest-3";
+# if BKR_PY3 is not present and NOT python3
+if [[ -z ${BKR_PY3} ]] || [[ ${BKR_PY3} != 1 ]]; then
+    test_command="nosetests ${*:--v bkr}";
 else
-    pytest_command="py.test-2";
+    test_command="pytest-3";
 fi
 
-env PYTHONPATH=../Client/src:../Common${PYTHONPATH:+:$PYTHONPATH} \
-    $pytest_command
+env PYTHONPATH=../Client/src:../Common${PYTHONPATH:+:$PYTHONPATH} ${test_command}
+


### PR DESCRIPTION
Attempted to use upstream repo changes (pull #152) in
Downstream repo and it fails as py.test-2 doesn't exist.
In reviewing the code, python2 test support seems
broken.  If you know otherwise, we can just close
this ticket and I'll keep my changes downstream only.