### PR TITLE
Add support for custom boot loaders

### DIFF
--- a/Common/bkr/common/schema/beaker-job.rng
+++ b/Common/bkr/common/schema/beaker-job.rng
@@ -589,6 +589,15 @@ the Free Software Foundation; either version 2 of the License, or
       </a:documentation>
       <attribute name="url"/>
     </element>
+    <optional>
+      <element name="image">
+        <a:documentation xml:lang="en">
+          Location of the installer netboot image. May be specified as
+          an absolute URL or as a path relative to the installation tree URL.
+        </a:documentation>
+        <attribute name="url"/>
+      </element>
+    </optional>
     <element name="arch">
       <a:documentation xml:lang="en">
         CPU architecture that the distro is built for.

--- a/IntegrationTests/src/bkr/inttest/server/test_jobs.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_jobs.py
@@ -104,6 +104,42 @@ class TestJobsController(DatabaseTestCase):
         self.assertIn('<arch value="i386"/>', roundtripped_xml)
         self.assertIn('<osversion major="RedHatEnterpriseLinux7" minor="0"/>', roundtripped_xml)
 
+    # https://bugzilla.redhat.com/show_bug.cgi?id=911515
+    def test_job_with_custom_distro_with_image_url_can_be_roundtripped(self):
+        complete_job_xml = '''
+                    <job>
+                        <whiteboard>
+                            so pretty
+                        </whiteboard>
+                        <recipeSet>
+                            <recipe>
+                                <distro>
+                                    <tree url="ftp://dummylab.example.com/distros/MyCustomLinux1.0/Server/aarch64/os/"/>
+                                    <initrd url="pxeboot/initrd"/>
+                                    <kernel url="pxeboot/vmlinuz"/>
+                                    <image  url="EFI/BOOT/grubaa64.efi"/>
+                                    <arch value="aarch64"/>
+                                    <osversion major="RedHatEnterpriseLinux8"/>
+                                </distro>
+                                <hostRequires/>
+                                <task name="/distribution/check-install"/>
+                            </recipe>
+                        </recipeSet>
+                    </job>
+                '''
+        xmljob = lxml.etree.fromstring(complete_job_xml)
+        job = testutil.call(self.controller.process_xmljob, xmljob, self.user)
+        roundtripped_xml = lxml.etree.tostring(job.to_xml(clone=True), pretty_print=True, encoding='utf8')
+        self.assertIn(
+                '<tree url="ftp://dummylab.example.com/distros/MyCustomLinux1.0/Server/aarch64/os/"/>',
+                roundtripped_xml
+        )
+        self.assertIn('<initrd url="pxeboot/initrd"/>', roundtripped_xml)
+        self.assertIn('<kernel url="pxeboot/vmlinuz"/>', roundtripped_xml)
+        self.assertIn('<image url="EFI/BOOT/grubaa64.efi"/>', roundtripped_xml)
+        self.assertIn('<arch value="aarch64"/>', roundtripped_xml)
+        self.assertIn('<osversion major="RedHatEnterpriseLinux8" minor="0"/>', roundtripped_xml)
+
     def test_complete_job_results(self):
         complete_job_xml = pkg_resources.resource_string('bkr.inttest', 'complete-job.xml')
         xmljob = lxml.etree.fromstring(complete_job_xml)
@@ -334,6 +370,7 @@ class TestJobsController(DatabaseTestCase):
         self.assertIsNone(recipe.installation.tree_url)
         self.assertIsNone(recipe.installation.initrd_path)
         self.assertIsNone(recipe.installation.kernel_path)
+        self.assertIsNone(recipe.installation.image_path)
         self.assertEqual(recipe.installation.arch.arch, u'i386')
         self.assertEqual(recipe.installation.distro_name, u'BlueShoeLinux5-5')
         self.assertEqual(recipe.installation.osmajor, u'BlueShoeLinux5')

--- a/LabController/src/bkr/labcontroller/provision.py
+++ b/LabController/src/bkr/labcontroller/provision.py
@@ -228,7 +228,8 @@ def handle_configure_netboot(command):
                           command['netboot']['distro_tree_id'],
                           command['netboot']['kernel_url'],
                           command['netboot']['initrd_url'],
-                          command['netboot']['kernel_options'])
+                          command['netboot']['kernel_options'],
+                          command['netboot']['image_url'])
 
 def handle_clear_netboot(command):
     netboot.clear_all(command['fqdn'])

--- a/LabController/src/bkr/labcontroller/test_netboot.py
+++ b/LabController/src/bkr/labcontroller/test_netboot.py
@@ -146,6 +146,10 @@ class ImagesBaseTestCase(NetBootTestCase):
         for _ in xrange(8 * 1024):
             self.initrd.write(chr(random.randrange(0, 256)) * 1024)
         self.initrd.flush()
+        self.image = tempfile.NamedTemporaryFile(prefix='test_netboot', suffix='image')
+        for _ in xrange(4 * 1024):
+            self.image.write(chr(random.randrange(0, 256)) * 1024)
+        self.image.flush()
 
 
 class ImagesTest(ImagesBaseTestCase):
@@ -185,7 +189,8 @@ class ArchBasedConfigTest(ImagesBaseTestCase):
     def configure(self, arch):
         netboot.configure_all(TEST_FQDN, arch, 1234,
                               'file://%s' % self.kernel.name,
-                              'file://%s' % self.initrd.name, "", self.tftp_root)
+                              'file://%s' % self.initrd.name, "",
+                              'file://%s' % self.image.name, self.tftp_root)
 
     def get_categories(self, arch):
         this = self.common_categories
@@ -636,7 +641,8 @@ class NetbootloaderTest(ImagesBaseTestCase):
         netboot.configure_all(TEST_FQDN, 'ppc64', 1234,
                               'file://%s' % self.kernel.name,
                               'file://%s' % self.initrd.name,
-                              'netbootloader=myawesome/netbootloader'
+                              'netbootloader=myawesome/netbootloader',
+                              None
                               )
         bootloader_config_symlink = os.path.join(self.tftp_root, 'bootloader', TEST_FQDN, 'image')
         self.assertTrue(os.path.lexists(bootloader_config_symlink))

--- a/Server/bkr/server/alembic/versions/140c5eea2836_add_image_path_to_installation_table.py
+++ b/Server/bkr/server/alembic/versions/140c5eea2836_add_image_path_to_installation_table.py
@@ -1,0 +1,28 @@
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+
+"""
+add image_path to Installation table
+
+Revision ID: 140c5eea2836
+Revises: 4b3a6065eba2
+Create Date: 2022-09-01 18:06:05.437563
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '140c5eea2836'
+down_revision = '4b3a6065eba2'
+
+
+def upgrade():
+    op.add_column('installation', sa.Column('image_path', sa.UnicodeText(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('installation', 'image_path')

--- a/Server/bkr/server/jobs.py
+++ b/Server/bkr/server/jobs.py
@@ -737,12 +737,14 @@ class Jobs(RPCRoot):
         tree_url = distro.find("tree").get("url")
         initrd_path = distro.find("initrd").get("url")
         kernel_path = distro.find("kernel").get("url")
+        image_path = distro.find("image").get("url") if distro.find("image") is not None else None
         osmajor = distro.find("osversion").get("major")
         osminor = distro.find("osversion").get("minor", "0")
         name = distro.find("name").get("value") if distro.find("name") is not None else None
         variant = distro.find("variant").get("value") if distro.find("variant") is not None else None
         return Installation(tree_url=tree_url, initrd_path=initrd_path, kernel_path=kernel_path,
-                            arch=arch, distro_name=name, osmajor=osmajor, osminor=osminor, variant=variant)
+                            arch=arch, distro_name=name, osmajor=osmajor, osminor=osminor,
+                            variant=variant, image_path=image_path)
 
     @expose('json')
     def update_recipe_set_response(self, recipe_set_id, response_id):

--- a/Server/bkr/server/labcontroller.py
+++ b/Server/bkr/server/labcontroller.py
@@ -449,6 +449,12 @@ class LabControllers(RPCRoot):
                     'initrd_url': urlparse.urljoin(distro_tree_url, installation.initrd_path),
                     'kernel_options': installation.kernel_options or '',
                 }
+                if installation.image_path:
+                    d["netboot"]["image_url"] = urlparse.urljoin(
+                        distro_tree_url, installation.image_path
+                    )
+                else:
+                    d['netboot']['image_url'] = None
                 if distro_tree:
                     d['netboot']['distro_tree_id'] = distro_tree.id
                 else:

--- a/Server/bkr/server/model/installation.py
+++ b/Server/bkr/server/model/installation.py
@@ -61,6 +61,7 @@ class Installation(DeclarativeMappedObject):
     osmajor = Column(UnicodeText)
     osminor = Column(UnicodeText)
     variant = Column(UnicodeText)
+    image_path = Column(UnicodeText)
 
     def distro_to_xml(self):
         distro_xml = E.distro(
@@ -70,6 +71,8 @@ class Installation(DeclarativeMappedObject):
             E.arch(value=self.arch.arch),
             E.osversion(major=self.osmajor, minor=self.osminor)
         )
+        if self.image_path:
+            distro_xml.append(E.image(url=self.image_path))
         if self.distro_name:
             distro_xml.append(E.name(value=self.distro_name))
         if self.variant:
@@ -77,16 +80,35 @@ class Installation(DeclarativeMappedObject):
         return distro_xml
 
     def __repr__(self):
-        return ('%s(created=%r, system=%r, distro_tree=%r, kernel_options=%r, '
-                'rendered_kickstart=%r, rebooted=%r, install_started=%r, '
-                'install_finished=%r, postinstall_finished=%r, tree_url=%r,'
-                ' initrd_path=%r, kernel_path=%r, arch=%r, distro_name=%r, osmajor=%r, osminor=%r,'
-                ' variant=%r)' % (self.__class__.__name__, self.created, self.system,
-                self.distro_tree, self.kernel_options, self.rendered_kickstart,
-                self.rebooted, self.install_started, self.install_finished,
-                self.postinstall_finished, self.tree_url, self.initrd_path,
-                self.kernel_path, self.arch, self.distro_name, self.osmajor, self.osminor,
-                self.variant))
+        return (
+            "%s(created=%r, system=%r, distro_tree=%r, kernel_options=%r, "
+            "rendered_kickstart=%r, rebooted=%r, install_started=%r, "
+            "install_finished=%r, postinstall_finished=%r, tree_url=%r,"
+            " initrd_path=%r, kernel_path=%r, arch=%r, distro_name=%r,"
+            " osmajor=%r, osminor=%r, image_path=%r,"
+            " variant=%r)"
+            % (
+                self.__class__.__name__,
+                self.created,
+                self.system,
+                self.distro_tree,
+                self.kernel_options,
+                self.rendered_kickstart,
+                self.rebooted,
+                self.install_started,
+                self.install_finished,
+                self.postinstall_finished,
+                self.tree_url,
+                self.initrd_path,
+                self.kernel_path,
+                self.arch,
+                self.distro_name,
+                self.osmajor,
+                self.osminor,
+                self.image_path,
+                self.variant,
+            )
+        )
 
     def __json__(self):
         return {
@@ -102,6 +124,7 @@ class Installation(DeclarativeMappedObject):
             'tree_url': self.tree_url,
             'initrd_path': self.initrd_path,
             'kernel_path': self.kernel_path,
+            'image_path': self.image_path,
             'arch': self.arch,
             'distro_name': self.distro_name,
             'osmajor': self.osmajor,


### PR DESCRIPTION
This allows for custom boot loaders to be used per installation.  Newer versions of RHEL may require newer versions of grub or the ppc64le boot loader to function properly.