### PR TITLE
Fix submods target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,5 @@ deps:
 	sudo $(DEPCMD) -y beaker.spec
 
 submods:
-	git submodules init
-	git submodules update
+	git submodule init
+	git submodule update


### PR DESCRIPTION
Fixes: #172
Fixes: acfabb4bf441 ("Devel patch to activate beaker from local git tree")