### PR TITLE
beaker-job schema: add optional attr 'retry' to task.fetch element

### DIFF
--- a/Common/bkr/common/schema/beaker-job.rnc
+++ b/Common/bkr/common/schema/beaker-job.rnc
@@ -464,7 +464,8 @@ task =
               "                "
             ]
           ]
-          attribute subdir { text }?
+          attribute subdir { text }?,
+          attribute retry { text }?
         },
         [
           a:documentation [

--- a/Common/bkr/common/schema/beaker-job.rng
+++ b/Common/bkr/common/schema/beaker-job.rng
@@ -453,6 +453,11 @@ the Free Software Foundation; either version 2 of the License, or
                   the task is at the root of the archive.
                 </a:documentation>
               </attribute>
+              <attribute name="retry">
+                <a:documentation xml:lang="en">
+                  Max retry number before give up fetching.
+                </a:documentation>
+              </attribute>
             </optional>
           </element>
           <optional>


### PR DESCRIPTION
so that we can implement the Restraint RFE[1] in more elegant way: by add optional attribute in fetch element:  
<fetch url="http://my.download.host/path" retry="8" />

ref[1]: https://github.com/restraint-harness/restraint/pull/293

the patch for Restraint:  
https://github.com/restraint-harness/restraint/commit/528c844596733851973ad5ed444c93aefac331ce