### PR TITLE
Fix broken extlinks in newer Sphinx versions.

### DIFF
--- a/documentation/conf.py
+++ b/documentation/conf.py
@@ -65,7 +65,7 @@ intersphinx_mapping = {'python': ('http://docs.python.org/', None),
                        'beakerdev': ('http://beaker-project.org/dev', None),
                       }
 extlinks = {
-    'issue': ('https://bugzilla.redhat.com/show_bug.cgi?id=%s', '#'),
+    'issue': ('https://bugzilla.redhat.com/show_bug.cgi?id=%s', '#%s'),
 }
 
 if six.PY3:


### PR DESCRIPTION
At this moment it is impossible to build documentation on a newer version of sphinx. 
This is basically a blocker for Fedora packages. 



```
Sphinx 6 introduced a breaking change for extlinks.
extlinks: Sphinx-6.0 will require base URL to contain exactly one \'%s\' and all other \'%\' need to be escaped as \'%%\'.'
```