### PR TITLE
bkr-job schema: add optional task attrs 'keepchanges', 'fetch_opts'

### DIFF
--- a/Common/bkr/common/schema/beaker-job.rnc
+++ b/Common/bkr/common/schema/beaker-job.rnc
@@ -439,7 +439,9 @@ task =
          "          "
        ]
      ]
-     attribute name { text }
+     attribute name { text },
+     attribute keepchanges { text }?,
+     attribute fetch_opts { text }?
      | (element fetch {
           [
             a:documentation [

--- a/Common/bkr/common/schema/beaker-job.rng
+++ b/Common/bkr/common/schema/beaker-job.rng
@@ -433,6 +433,19 @@ the Free Software Foundation; either version 2 of the License, or
             task must exist in Beaker's task library.
           </a:documentation>
         </attribute>
+	<optional>
+	  <attribute name="keepchanges">
+	    <a:documentation xml:lang="en">
+	      Enable the Restraint keepchanges feature.
+	    </a:documentation>
+	  </attribute>
+	  <attribute name="fetch_opts">
+	    <a:documentation xml:lang="en">
+	      Restraint fetch options, e.g:
+                fetch_opts="retry=8,timeo=16,abort-recipe-on-fetch-fail"
+                fetch_opts="retry=8,keepchanges"
+	    </a:documentation>
+	</optional>
         <group>
           <element name="fetch">
             <attribute name="url">


### PR DESCRIPTION
Now Restraint supports new features by adding new xml element e.g:  
<task name="/fs/es" keepchanges="yes" fetch_opts="retry=8,timeo=8">  

But Beaker side has not updated the job schema, This results in us not  
being able to use these new features of Restraint in integrated mode.