### PR TITLE
Use GitHub Archive as source for tarball

### DIFF
--- a/beaker.spec
+++ b/beaker.spec
@@ -25,7 +25,7 @@ Group:          Applications/Internet
 License:        GPLv2+ and BSD
 URL:            https://beaker-project.org/
 
-Source0:        https://beaker-project.org/releases/%{name}-%{upstream_version}.tar.xz
+Source0:        https://github.com/beaker-project/beaker/archive/%{name}-%{upstream_version}.tar.gz
 # Third-party JS/CSS libraries which are built into Beaker's generated JS/CSS
 # (these are submodules in Beaker's git tree, the commit hashes here should
 # correspond to the submodule commits)


### PR DESCRIPTION
Using GitHub Archive as a source allows us to create RPMs as soon as a new tag is present in the repository, instead of waiting until we have a mirror stored on Beaker-Project.org. Ideally, we would like to reverse this workflow: we publish the tag and then use automation to mirror it to Beaker-Project.org (with rest of the artifacts - e.g. RPMs )

We do the same thing for Restraint at this moment.