### PR TITLE
Update -n parameter in %setup macro

### DIFF
--- a/beaker.spec
+++ b/beaker.spec
@@ -317,7 +317,7 @@ newly imported distros.
 %endif
 
 %prep
-%setup -q -n %{name}-%{upstream_version}
+%setup -q -n %{name}-%{name}-%{upstream_version}
 tar -C Server/assets/bootstrap --strip-components=1 -xzf %{SOURCE1}
 tar -C Server/assets/font-awesome --strip-components=1 -xzf %{SOURCE2}
 tar -C Server/assets/typeahead.js --strip-components=1 -xzf %{SOURCE3}


### PR DESCRIPTION
GitHub archives are created with the repository name as a prefix.

For instance, requesting an archive from:
```
https://github.com/beaker-project/beaker/archive/beaker-28.3.tar.gz
``` 
results in a file named beaker-beaker-28.3.tar.gz, as indicated by the content-disposition header:
```
</snip>
< content-disposition: attachment; filename=beaker-beaker-28.3.tar.gz
</snip>
```
Although the Spectool and RPM toolchain store the file based on the requested path, resulting in beaker-28.3.tar.gz, the internal structure of the tarball reflects the original GitHub archive naming. This discrepancy can cause issues during the RPM build process.

This commit adjusts the %setup -n parameter in the spec file to align with the GitHub archive's internal structure, ensuring correct extraction and building. 

The change has been manually tested in COPR and with rpmbuild/spectool.
We can't catch this problem in CI right now because of the way Packit works. Packit replaces both sources and the %setup macro.