### PR TITLE
Run init inside the container that forwards signals

### DIFF
--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -55,6 +55,7 @@ jobs:
         test-target: ["bkr.inttest.client", "bkr.inttest.labcontroller", "bkr.inttest.server"]
     container:
       image: centos:7
+      options: --init
     services:
       database:
         image: mariadb:latest


### PR DESCRIPTION
While implementing unit tests, I noticed this issue, which should also be considered for integration tests since the lab-controller operates in that environment. Although these conditions haven't been encountered in our current tests, they could potentially arise in future tests.
Closes: #205