### PR TITLE
chore: allow usage of `https` in URL for distro tree

### DIFF
--- a/Server/bkr/server/distrotrees.py
+++ b/Server/bkr/server/distrotrees.py
@@ -129,7 +129,7 @@ class DistroTrees(RPCRoot):
             except NoResultFound:
                 raise cherrypy.HTTPError(status=400,
                         message='No such lab controller %r' % kwargs['lab'])
-        base = distro_tree.url_in_lab(lc, scheme='http')
+        base = distro_tree.url_in_lab(lc, scheme=['https', 'http'])
         if not base:
             raise cherrypy.HTTPError(status=404,
                     message='%s is not present in lab %s' % (distro_tree, lc))

--- a/Server/bkr/server/model/distrolibrary.py
+++ b/Server/bkr/server/model/distrolibrary.py
@@ -792,7 +792,7 @@ class DistroTree(DeclarativeMappedObject, ActivityMixin):
                 if s in urls:
                     return urls[s]
         else:
-            for s in ['nfs', 'http', 'ftp']:
+            for s in ['nfs', 'https', 'http', 'ftp']:
                 if s in urls:
                     return urls[s]
             # caller didn't specify any schemes, so pick anything if we have it


### PR DESCRIPTION
When specifying the URL for the location of the distro for a lab controller, allow usage of `https` URLs.

Previously you could add an `https` URL, but then when provisioning the system it would fail with the error:
  Command 1234566 aborted: No usable URL found for distro tree 123 in lab lab1.example.com