### PR TITLE
CI: Use MariaDB 10-ubi as DB for tests

### DIFF
--- a/.github/workflows/review-checks.yml
+++ b/.github/workflows/review-checks.yml
@@ -43,7 +43,7 @@ jobs:
       options: --init
     services:
       database:
-        image: mariadb:latest
+        image: mariadb:10-ubi
         env:
           MYSQL_USER: ${{ env.MYSQL_USER }}
           MYSQL_PASSWORD: ${{ env.MYSQL_PASSWORD }}


### PR DESCRIPTION
This pull request locks the DB to MariaDB 10 to avoid random failures in test cases. We can extend the matrix if we want to support additional databases or versions, but we need to make sure we can configure them properly for production.