### PR TITLE
xmlrpc3: remove missing arguments

### DIFF
--- a/Common/bkr/common/xmlrpc3.py
+++ b/Common/bkr/common/xmlrpc3.py
@@ -356,7 +356,7 @@ class CookieTransport(xmlrpclib.Transport):
         rc = kerberos.authGSSClientClean(vc)
         if rc != 1:
             errcode = 401
-            errmsg = "KERBEROS: Could not clean-up GSSAPI: %s/%s" % (ex[0][0], ex[1][0])
+            errmsg = "KERBEROS: Could not clean-up GSSAPI"
             raise xmlrpclib.ProtocolError(host + handler, errcode, errmsg, headers)
 
     def single_request(self, host, handler, request_body, verbose=0):


### PR DESCRIPTION
ex is not defined in this context, remove it and just log an error that the cleanup failed.