### PR TITLE
MemoryError seen on expire_distros execution

### DIFF
--- a/LabController/cron.hourly/beaker_expire_distros
+++ b/LabController/cron.hourly/beaker_expire_distros
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec flock -n /var/run/beaker_expire_distros.cron.lock beaker-expire-distros
+exec flock -n /var/run/beaker_expire_distros.cron.lock beaker-expire-distros --arch=all


### PR DESCRIPTION
When the beaker_expire_distros hourly cron job ran, the MemoryError is seen on the lab controller as well as Server. This same error is seen when executing the bkr CLI 'bkr distro-trees-list --limit=8000 --labcontroller=hostname | grep "ID:" | wc -l'
As it turns out, expire_distros is calling the same underlying get method.  The error is sporadic.  It is likely due to difficulty attaining a contiguous memory chunk for a lot of data.  The solution is to get smaller chunks.  Similar filters as the cli distro-trees-list are now allow thru expired_distros.py which passes them to the same get operation. These filters also allows for more variation for beaker_expire_distros. Stepping thru architectures seemed to be the best choice of filters for the chunks.  When --arch=all, the expire_distros.py code knows to step thru a list of arch to perform removal instead of trying to do it all at once. So the cron job is updated to include --arch=all.