### PR TITLE
Support latest distro args in pxemenu

### DIFF
--- a/LabController/src/bkr/labcontroller/pxemenu-templates/efi-grub-menu
+++ b/LabController/src/bkr/labcontroller/pxemenu-templates/efi-grub-menu
@@ -4,7 +4,7 @@
 
 title {{ distro_tree.distro_name }} {{ distro_tree.variant }} {{ distro_tree.arch }}
     root (nd)
-    kernel /distrotrees/{{ distro_tree.distro_tree_id }}/kernel method={{ distro_tree.available|get_url }} repo={{ distro_tree.available|get_url }}
+    kernel /distrotrees/{{ distro_tree.distro_tree_id }}/kernel {{ osmajor|get_method(distro_tree.available) }} {{ osmajor|get_repo_prefix }}repo={{ distro_tree.available|get_url }}
     initrd /distrotrees/{{ distro_tree.distro_tree_id }}/initrd
 {% endfor %}
 {% endfor %}

--- a/LabController/src/bkr/labcontroller/pxemenu-templates/grub2-menu
+++ b/LabController/src/bkr/labcontroller/pxemenu-templates/grub2-menu
@@ -12,7 +12,7 @@ submenu "{{ osversion }}" {
 
 {% for distro_tree in distro_trees %}
 menuentry "{{ distro_tree.distro_name }} {{ distro_tree.variant }} {{ distro_tree.arch }}" {
-    linux /distrotrees/{{ distro_tree.distro_tree_id }}/kernel method={{ distro_tree.available|get_url }} repo={{
+    linux /distrotrees/{{ distro_tree.distro_tree_id }}/kernel {{ osmajor|get_method(distro_tree.available) }} {{ osmajor|get_repo_prefix }}repo={{
     distro_tree.available| get_url }}
     initrd /distrotrees/{{ distro_tree.distro_tree_id }}/initrd
 }

--- a/LabController/src/bkr/labcontroller/pxemenu-templates/ipxe-menu
+++ b/LabController/src/bkr/labcontroller/pxemenu-templates/ipxe-menu
@@ -36,7 +36,7 @@ choose target && goto ${target} || goto {{ osmajor }}
 
 {% for distro_tree in distro_trees %}
 :{{ distro_tree.distro_name.replace(" ", "") }}-{{ distro_tree.variant.replace(" ", "") }}-{{ distro_tree.arch.replace(" ", "") }}
-set options kernel initrd=initrd method={{ distro_tree.available|get_url }} repo={{ distro_tree.available|get_url }} {{ distro_tree.kernel_options }}
+set options kernel initrd=initrd {{ osmajor|get_method(distro_tree.available) }} {{ osmajor|get_repo_prefix }}repo={{ distro_tree.available|get_url }} {{ distro_tree.kernel_options }}
 echo Kernel command line: ${options}
 prompt --timeout 5000 Press any key for additional options... && set opts 1 || clear opts
 isset ${opts} && echo -n Additional options: ${} ||

--- a/LabController/src/bkr/labcontroller/pxemenu-templates/pxelinux-menu
+++ b/LabController/src/bkr/labcontroller/pxemenu-templates/pxelinux-menu
@@ -20,9 +20,9 @@ menu title {{ osversion }}
 label {{ distro_tree.distro_name }}-{{ distro_tree.variant }}-{{ distro_tree.arch }}
     menu title {{ distro_tree.distro_name }} {{ distro_tree.variant }} {{ distro_tree.arch }}
     kernel /distrotrees/{{ distro_tree.distro_tree_id }}/kernel
-    append initrd=/distrotrees/{{ distro_tree.distro_tree_id }}/initrd method={{ distro_tree.available|get_url }} repo={{ distro_tree.available|get_url }} {{ distro_tree.kernel_options }}
-
+    append initrd=/distrotrees/{{ distro_tree.distro_tree_id }}/initrd {{ osmajor|get_method(distro_tree.available) }} {{ osmajor|get_repo_prefix }}repo={{ distro_tree.available|get_url }} {{ distro_tree.kernel_options }}
 {% endfor %}
+
 menu end
 
 {% endfor %}

--- a/LabController/src/bkr/labcontroller/pxemenu.py
+++ b/LabController/src/bkr/labcontroller/pxemenu.py
@@ -31,6 +31,43 @@ def _get_url(available):
                      [url for lc, url in available])
 
 
+def _is_newer_distro(osmajor):
+    if (osmajor.lower() in ('fedoraeln', 'fedorarawhide')):
+        return True
+
+    result = re.search(r"([a-zA-Z]+)(\d+)", osmajor)
+    if result is None:
+        return False
+    distro = result.groups()[0]
+    version = int(result.groups()[1])
+    if distro in ('RedHatEnterpriseLinux', 'CentOSStream') and version > 8:
+          return True
+    if distro == 'Fedora' and version > 33:
+          return True
+    return False
+
+
+def _get_repo_prefix(osmajor):
+    """
+    Newer distros require prefix of 'inst.' to repo kernel variable
+    which ultimately results in inst.repo.
+    """
+    if (_is_newer_distro(osmajor)):
+        return 'inst.'
+    return ''
+
+
+def _get_method(osmajor, available):
+    """
+    Older distros use 'method' kernel variable which has been deprecated by
+    inst.repo in newer distros.
+    """
+    if (_is_newer_distro(osmajor)):
+        return ''
+    url = _get_url(available)
+    return 'method='+url
+
+
 def _group_distro_trees(distro_trees):
     grouped = {}
     for dt in distro_trees:
@@ -77,6 +114,8 @@ def _get_all_images(tftp_root, distro_trees):
 template_env = Environment(loader=PackageLoader('bkr.labcontroller', 'pxemenu-templates'),
                            trim_blocks=True)
 template_env.filters['get_url'] = _get_url
+template_env.filters['get_repo_prefix'] = _get_repo_prefix
+template_env.filters['get_method'] = _get_method
 
 
 def write_menu(menu, template_name, distro_trees):


### PR DESCRIPTION
For latest distros, the variables 'method' and 'repos' are not supported in beaker pxemenu.  Replace with 'inst.repos' instead.  The latest distros are
RHEL9, CentOSStream9, FedoraRawhide, FedoraELN, and Fedora34 and up.