### PR TITLE
grubport snippet fails for RHEL9

### DIFF
--- a/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
@@ -1732,6 +1732,32 @@ python-glanceclient
             </job>
             ''', system)
         self.assertIn('--port=0x02f8', recipe.installation.rendered_kickstart.kickstart)
+        self.assertIn('for file in /boot/grub2/grub.cfg /boot/efi/EFI/redhat/grub.cfg ; do', recipe.installation.rendered_kickstart.kickstart)
+
+    def test_grubport_rhel9(self):
+        system = data_setup.create_system(arch=u'x86_64', status=u'Automated',
+                lab_controller=self.lab_controller)
+        system.provisions[system.arch[0]] = Provision(arch=system.arch[0],
+                ks_meta=u'grubport=0x02f8')
+        recipe = self.provision_recipe('''
+            <job>
+                <whiteboard/>
+                <recipeSet>
+                    <recipe>
+                        <distroRequires>
+                            <distro_name op="=" value="RHEL-9.0.0-20201122.0" />
+                            <distro_variant op="=" value="BaseOS" />
+                            <distro_arch op="=" value="x86_64" />
+                        </distroRequires>
+                        <hostRequires/>
+                        <task name="/distribution/check-install" />
+                        <task name="/distribution/reservesys" />
+                    </recipe>
+                </recipeSet>
+            </job>
+            ''', system)
+        self.assertIn('--port=0x02f8', recipe.installation.rendered_kickstart.kickstart)
+        self.assertIn('for file in /boot/grub2/grub.cfg ; do', recipe.installation.rendered_kickstart.kickstart)
 
     def test_rhel5_devices(self):
         system = data_setup.create_system(arch=u'x86_64', status=u'Automated',

--- a/Server/bkr/server/snippets/grubport
+++ b/Server/bkr/server/snippets/grubport
@@ -8,7 +8,11 @@ done
 # set --port for GRUB2
 if [ -e "/etc/default/grub" ] ; then
     sed --in-place=.orig -e '/^GRUB_SERIAL_COMMAND="serial/ {s/--unit=[0-9]\+//; s/"$/ --port={{ grubport }}"/}' /etc/default/grub
+{% if distro.osversion.osmajor.name == 'RedHatEnterpriseLinux' and distro.osversion.osmajor.number | int >= 9 %}
+    for file in /boot/grub2/grub.cfg ; do
+{% else %}
     for file in /boot/grub2/grub.cfg /boot/efi/EFI/redhat/grub.cfg ; do
+{% endif %}
         if [ -f "$file" ] && [ ! -L "$file" ] ; then
             grub2-mkconfig -o "$file"
         fi


### PR DESCRIPTION
Beaker users reported grub.cfg files being overwritten by Beaker causing job failures.  I determined that this occurs only when the system is configured with
    Install Options --> Kickstart Metadata --> grubport=0x03f8
This grubport config causes the grubport snippet to expand in the kickstart file.  When looking at the two possible grub.cfg files, it looks like RHEL team now using /boot/efi/EFI/redhat/grub.cfg as a programmable link to /boot/grub2/grub.cfg file. To continue to support configuration of serial port, this changeset will only try to configure /boot/grub2/grub.cfg for RHEL9.  All other distros will remain the unchanged.