### PR TITLE
Make tests compatible with Python 3

### DIFF
--- a/IntegrationTests/src/bkr/inttest/assertions.py
+++ b/IntegrationTests/src/bkr/inttest/assertions.py
@@ -8,6 +8,9 @@ import difflib
 import time
 import datetime
 
+from six.moves import range
+
+
 def assert_sorted(things, key=None):
     """
     Asserts that the given sequence is in sorted order.
@@ -15,7 +18,7 @@ def assert_sorted(things, key=None):
     if len(things) == 0: return
     if key is not None:
         things = map(key, things)
-    for n in xrange(1, len(things)):
+    for n in range(1, len(things)):
         if things[n] < things[n - 1]:
             raise AssertionError('Not in sorted order, found %r after %r' %
                     (things[n], things[n - 1]))

--- a/IntegrationTests/src/bkr/inttest/client/test_system_status.py
+++ b/IntegrationTests/src/bkr/inttest/client/test_system_status.py
@@ -11,10 +11,7 @@ from json import loads
 from bkr.inttest import data_setup
 from bkr.inttest.client import run_client, ClientError, ClientTestCase
 
-try:
-    unicode('')
-except:
-    unicode = str
+import six
 
 
 class SystemStatusTest(ClientTestCase):
@@ -44,7 +41,7 @@ class SystemStatusTest(ClientTestCase):
         json_out = loads(json_out)
         current_reservation = json_out.get('current_reservation')
         self.assertEqual(current_reservation.get('user_name'),
-            unicode(system.user))
+            six.text_type(system.user))
         self.assertEqual(current_reservation.get('recipe_id'), '%s' % \
             system.open_reservation.recipe.id)
         self.assertEqual(json_out.get('condition'), '%s' % system.status)
@@ -76,7 +73,7 @@ class SystemStatusTest(ClientTestCase):
             '--format', 'json'])
         json_out = loads(json_out)
         current_reservation = json_out['current_reservation']
-        self.assertEqual(current_reservation.get('user_name'), unicode(user))
+        self.assertEqual(current_reservation.get('user_name'), six.text_type(user))
         self.assertEqual(json_out.get('current_loan'), None)
         self.assertEqual(json_out.get('condition'), '%s' % SystemStatus.manual)
 
@@ -100,7 +97,7 @@ class SystemStatusTest(ClientTestCase):
         json_out = loads(json_out)
         self.assertEqual(json_out.get('current_reservation'), None)
         self.assertEqual(json_out.get('current_loan'), None)
-        self.assertEqual(json_out.get('condition'), unicode(system.status))
+        self.assertEqual(json_out.get('condition'), six.text_type(system.status))
 
         # Human friendly output
         human_out = run_client(['bkr', 'system-status', system.fqdn])

--- a/IntegrationTests/src/bkr/inttest/client/test_task_add.py
+++ b/IntegrationTests/src/bkr/inttest/client/test_task_add.py
@@ -6,12 +6,10 @@
 
 from turbogears.database import session
 from turbogears import config
-from bkr.inttest import data_setup
 from bkr.inttest.client import run_client, ClientError, ClientTestCase
 import pkg_resources
 from os import path
 from bkr.server.model import Task, OSMajor
-from bkr.server.model.tasklibrary import TaskLibrary
 
 
 class TaskAddTest(ClientTestCase):

--- a/IntegrationTests/src/bkr/inttest/client/test_update_openstack_trust.py
+++ b/IntegrationTests/src/bkr/inttest/client/test_update_openstack_trust.py
@@ -76,7 +76,7 @@ class UpdateOpenStackTrustTest(ClientTestCase):
                         '--os-project-name=beaker'],
                        config=self.client_config)
             self.fail('should raise a ClientError')
-        except ClientError, e:
+        except ClientError as e:
             self.assertIn(
                     'Could not authenticate with OpenStack using your credentials',
                     e.stderr_output)

--- a/IntegrationTests/src/bkr/inttest/http_server.py
+++ b/IntegrationTests/src/bkr/inttest/http_server.py
@@ -21,13 +21,14 @@ It also treats the following paths specially:
     path information is ignored.
 """
 
-import os, os.path
+import os
+import os.path
 import re
 import time
 import shutil
-import urlparse
 import mimetypes
-import wsgiref.util, wsgiref.simple_server
+import wsgiref.util
+import wsgiref.simple_server
 
 class Application(object):
 

--- a/IntegrationTests/src/bkr/inttest/kickstart_helpers.py
+++ b/IntegrationTests/src/bkr/inttest/kickstart_helpers.py
@@ -5,12 +5,12 @@
 # (at your option) any later version.
 
 import pkg_resources
-import urlparse
-import re
 import jinja2
-import tempfile
 import difflib
+import six
+from six.moves import urllib
 from sqlalchemy.orm.exc import NoResultFound
+
 from bkr.inttest import data_setup, get_server_base
 from bkr.server.bexceptions import DatabaseLookupError
 from bkr.server.model import session, Distro, DistroTree, Arch, DistroTreeRepo
@@ -80,10 +80,10 @@ def compare_expected(name, recipe_id, actual):
     vars = {
         '@RECIPEID@': str(recipe_id),
         '@BEAKER@': get_server_base(),
-        '@REPOS@': urlparse.urljoin(get_server_base(), '/repos/'),
-        '@HARNESS@': urlparse.urljoin(get_server_base(), '/harness/'),
+        '@REPOS@': urllib.parse.urljoin(get_server_base(), '/repos/'),
+        '@HARNESS@': urllib.parse.urljoin(get_server_base(), '/harness/'),
     }
-    for var, value in vars.iteritems():
+    for var, value in six.iteritems(vars):
         expected = expected.replace(var, value)
     expected = expected.rstrip('\n')
     actual = actual.rstrip('\n')

--- a/IntegrationTests/src/bkr/inttest/labcontroller/test_distro_import.py
+++ b/IntegrationTests/src/bkr/inttest/labcontroller/test_distro_import.py
@@ -741,8 +741,6 @@ class DistroImportTest(LabControllerTestCase):
                                                    u'type': u'uimage'},
                                                   {u'path': u'images/pxeboot/uInitrd',
                                                    u'type': u'uinitrd'},],
-                                      u'arches': [
-                                                  ],
                                       u'arches': [],
                                       u'urls': [u'http://localhost:19998/Fedora-rawhide/armhfp/os/'],
                                       u'arch': u'armhfp',

--- a/IntegrationTests/src/bkr/inttest/labcontroller/test_watchdog.py
+++ b/IntegrationTests/src/bkr/inttest/labcontroller/test_watchdog.py
@@ -9,7 +9,6 @@
 import os, os.path
 import time
 import pkg_resources
-import gevent.hub
 from turbogears.database import session
 from bkr.common.helpers import makedirs_ignore
 from bkr.labcontroller.config import get_conf

--- a/IntegrationTests/src/bkr/inttest/mail_capture.py
+++ b/IntegrationTests/src/bkr/inttest/mail_capture.py
@@ -12,8 +12,8 @@ See bkr.server.test.selenium.test_systems for an example of how to use this.
 """
 
 import threading
-import smtpd
-import asyncore
+import smtpd  # TODO: Removed in Python 3.12
+import asyncore  # TODO: Removed in Python 3.12
 import logging
 
 log = logging.getLogger(__name__)

--- a/IntegrationTests/src/bkr/inttest/server/requests_utils.py
+++ b/IntegrationTests/src/bkr/inttest/server/requests_utils.py
@@ -5,13 +5,15 @@
 # (at your option) any later version.
 
 import json
-import xmlrpclib
 import requests
+from six.moves import xmlrpc_client
+
 from bkr.inttest import data_setup, get_server_base
+
 
 def xmlrpc(url, xmlrpc_method, xmlrpc_args, **kwargs):
     # marshal XMLRPC request
-    data = xmlrpclib.dumps(tuple(xmlrpc_args), methodname=xmlrpc_method, allow_none=True)
+    data = xmlrpc_client.dumps(tuple(xmlrpc_args), methodname=xmlrpc_method, allow_none=True)
     # add Content-Type request header
     headers = kwargs.pop('headers', {})
     headers.update({'Content-Type': 'text/xml'})

--- a/IntegrationTests/src/bkr/inttest/server/test_database_migration.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_database_migration.py
@@ -21,6 +21,7 @@ from bkr.server.model import (
     RecipeTaskResult, Command, CommandStatus, LogRecipeTaskResult, DataMigration, Job,
     SystemSchedulerStatus, Permission, Installation, Arch
 )
+import six
 
 
 def has_initial_sublist(larger, prefix):
@@ -383,7 +384,7 @@ class MigrationTest(unittest.TestCase):
             if table_name == 'command_queue':
                 # may be left over from 22
                 actual_indexes = dict((name, cols) for name, cols
-                                      in actual_indexes.iteritems()
+                                      in six.iteritems(actual_indexes)
                                       if cols != ['distro_tree_id'])
             if table_name == 'virt_resource':
                 if 'ix_virt_resource_mac_address' in actual_indexes:
@@ -455,7 +456,7 @@ class MigrationTest(unittest.TestCase):
                 if has_initial_sublist(table.primary_key.columns.values(),
                                        constraint.columns.values()):
                     continue
-                name = constraint.name or constraint.columns.values()[0].name
+                name = constraint.name or list(constraint.columns.values())[0].name
                 expected_indexes[name] = cols
         # Similarly, if we have defined a foreign key without an
         # explicit index, InnoDB creates one implicitly.
@@ -463,7 +464,7 @@ class MigrationTest(unittest.TestCase):
             if any(index_cols[0] == fk.parent.name
                    for index_cols in expected_indexes.values()):
                 continue
-            if table.primary_key.columns.values()[0] == fk.parent:
+            if list(table.primary_key.columns.values())[0] == fk.parent:
                 continue
             expected_indexes[fk.name or fk.parent.name] = [fk.parent.name]
         return expected_indexes

--- a/IntegrationTests/src/bkr/inttest/server/test_jobs.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_jobs.py
@@ -6,14 +6,11 @@
 
 import datetime
 import lxml.etree
-import os.path
 import pkg_resources
 from turbogears import testutil
 from turbogears.database import session
 from bkr.server.bexceptions import BX
 from bkr.inttest import data_setup, with_transaction, DatabaseTestCase, get_server_base
-from bkr.server.model import TaskPackage
-
 
 class TestJobsController(DatabaseTestCase):
 

--- a/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_kickstart.py
@@ -13,10 +13,10 @@ import subprocess
 import sys
 import tempfile
 import unittest
-from itertools import izip_longest
 
 import lxml.etree
 import pkg_resources
+import six
 
 from bkr.inttest import data_setup, get_server_base, Process
 from bkr.inttest.kickstart_helpers import (
@@ -4331,5 +4331,5 @@ volgroup bootvg --pesize=32768 pv.01
             ''' % '\n'.join(payload), self.system)
         ks = recipe.installation.rendered_kickstart.kickstart
         ks_lines = ks.splitlines()
-        for actual, expected in izip_longest(payload, ks_lines):
+        for actual, expected in six.moves.zip_longest(payload, ks_lines):
             self.assert_(actual == expected, ks)

--- a/IntegrationTests/src/bkr/inttest/server/test_lab_controller.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_lab_controller.py
@@ -4,10 +4,8 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-import pkg_resources
 from turbogears.database import session
 from bkr.server.model import TaskStatus, RecipeSet, LabController, System
-from bkr.server.bexceptions import BX
 from bkr.inttest import data_setup, DatabaseTestCase
 
 class TestLabController(DatabaseTestCase):

--- a/IntegrationTests/src/bkr/inttest/server/test_mail.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_mail.py
@@ -400,7 +400,7 @@ class GroupMembershipNotificationTest(DatabaseTestCase):
         try:
             bkr.server.mail.group_membership_notify(member, group, owner, 'Unchanged')
             self.fail('Must fail or die')
-        except ValueError, e:
+        except ValueError as e:
             self.assert_('Unknown action' in str(e))
 
     # https://bugzilla.redhat.com/show_bug.cgi?id=1136748

--- a/IntegrationTests/src/bkr/inttest/server/test_rdf.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_rdf.py
@@ -4,7 +4,6 @@
 # the Free Software Foundation; either version 2 of the License, or
 # (at your option) any later version.
 
-from decimal import Decimal
 from turbogears.database import session
 from bkr.inttest import data_setup, get_server_base, DatabaseTestCase
 from bkr.server.model import Cpu, Arch

--- a/IntegrationTests/src/bkr/inttest/server/test_reporting_queries.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_reporting_queries.py
@@ -9,7 +9,6 @@ import datetime
 from decimal import Decimal
 from turbogears.database import session
 from sqlalchemy.sql import text
-from bkr.server import dynamic_virt
 from bkr.server.model import System, RecipeTask, Cpu, SystemStatus, \
     SystemActivity, TaskPriority, RecipeSetActivity, VirtResource, \
     GuestResource

--- a/IntegrationTests/src/bkr/inttest/server/test_utilisation.py
+++ b/IntegrationTests/src/bkr/inttest/server/test_utilisation.py
@@ -5,11 +5,15 @@
 # (at your option) any later version.
 
 import datetime
+
+import six
 from turbogears.database import session
+
 from bkr.server.model import SystemStatus, SystemStatusDuration, System, Arch
 from bkr.server.utilisation import system_utilisation, \
         system_utilisation_counts, system_utilisation_counts_by_group
 from bkr.inttest import data_setup, DatabaseTestCase
+
 
 class SystemUtilisationTest(DatabaseTestCase):
 
@@ -54,7 +58,7 @@ class SystemUtilisationTest(DatabaseTestCase):
         self.assertEqual(u['idle_automated'], datetime.timedelta(days=2))
         self.assertEqual(u['idle_broken'], datetime.timedelta(days=1))
         self.assertEqual(u['idle_removed'], datetime.timedelta(0))
-        self.assertEqual(sum((v for k, v in u.iteritems()), datetime.timedelta(0)),
+        self.assertEqual(sum((v for k, v in six.iteritems(u)), datetime.timedelta(0)),
                 datetime.timedelta(days=4))
 
     def test_idle_with_status_duration_covering_entire_period(self):
@@ -80,7 +84,7 @@ class SystemUtilisationTest(DatabaseTestCase):
         u = system_utilisation(system, datetime.datetime(2010, 1, 1, 0, 0, 0),
                 datetime.datetime(2010, 1, 5, 0, 0, 0))
         self.assertEqual(u['idle_automated'], datetime.timedelta(days=2))
-        self.assertEqual(sum((v for k, v in u.iteritems()), datetime.timedelta(0)),
+        self.assertEqual(sum((v for k, v in six.iteritems(u)), datetime.timedelta(0)),
                 datetime.timedelta(days=2))
 
     def test_system_removed_during_period(self):
@@ -99,7 +103,7 @@ class SystemUtilisationTest(DatabaseTestCase):
                 datetime.datetime(2010, 1, 5, 0, 0, 0))
         self.assertEqual(u['idle_automated'], datetime.timedelta(days=2))
         self.assertEqual(u['idle_removed'], datetime.timedelta(days=2))
-        self.assertEqual(sum((v for k, v in u.iteritems()), datetime.timedelta(0)),
+        self.assertEqual(sum((v for k, v in six.iteritems(u)), datetime.timedelta(0)),
                 datetime.timedelta(days=4))
 
     def test_counts(self):
@@ -150,7 +154,7 @@ class SystemUtilisationTest(DatabaseTestCase):
         counts = system_utilisation_counts_by_group(Arch.arch,
                 System.query.join(System.arch)
                 .filter(System.lab_controller == lc))
-        print counts
+        print(counts)
         self.assertEqual(counts['ia64']['recipe'], 1)
         self.assertEqual(counts['ia64']['manual'], 1)
         self.assertEqual(counts['ppc']['manual'], 1)

--- a/IntegrationTests/src/bkr/inttest/server/tools/test_create_kickstart.py
+++ b/IntegrationTests/src/bkr/inttest/server/tools/test_create_kickstart.py
@@ -5,11 +5,8 @@
 # (at your option) any later version.
 
 import os
-import sys
 import tempfile
 import shutil
-import subprocess
-from cStringIO import StringIO
 from turbogears.database import session
 from bkr.common import __version__
 from bkr.inttest import data_setup, DatabaseTestCase
@@ -17,9 +14,8 @@ from bkr.inttest.kickstart_helpers import create_rhel62, create_rhel62_server_x8
     create_lab_controller, create_x86_64_automated, compare_expected, \
     jinja_choice_loader, create_user
 from bkr.inttest.server.tools import run_command, CommandError
-from bkr.server.tools import create_kickstart
-from bkr.server.kickstart import template_env
 from bkr.server.model import Task, User, Recipe, Provision, Arch, OSMajorInstallOptions
+
 
 class CreateKickstartTest(DatabaseTestCase):
 

--- a/IntegrationTests/src/bkr/inttest/server/tools/test_init.py
+++ b/IntegrationTests/src/bkr/inttest/server/tools/test_init.py
@@ -16,7 +16,6 @@ core functions.
 from turbogears.database import session, metadata
 from bkr.common import __version__
 from bkr.server.model import User, Group
-from bkr.server.tools.init import populate_db
 from bkr.inttest import data_setup, DatabaseTestCase
 from bkr.inttest.server.tools import run_command
 

--- a/IntegrationTests/src/bkr/inttest/server/tools/test_log_delete.py
+++ b/IntegrationTests/src/bkr/inttest/server/tools/test_log_delete.py
@@ -50,7 +50,7 @@ class LogDelete(DatabaseTestCase):
     def make_dir(self, dir):
         try:
             os.makedirs(dir)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EEXIST:
                 pass
             else:
@@ -232,7 +232,7 @@ class RemoteLogDeletionTest(DatabaseTestCase):
             self.addCleanup(self.archive_server.stop)
         try:
             os.mkdir(self.recipe_logs_dir)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.EEXIST:
                 # perhaps something else created it and did not clean it up
                 pass

--- a/IntegrationTests/src/bkr/inttest/server/webdriver_utils.py
+++ b/IntegrationTests/src/bkr/inttest/server/webdriver_utils.py
@@ -9,7 +9,6 @@ from __future__ import absolute_import
 import json
 from selenium.common.exceptions import NoSuchElementException
 from selenium.webdriver.support.ui import Select, WebDriverWait
-from selenium import webdriver
 from bkr.inttest import data_setup, get_server_base
 
 def delete_and_confirm(browser, ancestor_xpath, delete_text='Delete'):


### PR DESCRIPTION
This pull request only contains changes to make it compatible with Python 3 in terms of syntax and imports. 
We still need to convert part of the integration suite to make it work. There are a bunch of dependencies on the server part.

Unused imports are removed to reduce the issues with transition