### PR TITLE
Support loading files from XDG_CONFIG_HOME

### DIFF
--- a/Client/src/bkr/client/__init__.py
+++ b/Client/src/bkr/client/__init__.py
@@ -31,15 +31,32 @@ def get_user_config_file():
             raise SystemExit(1)
         return user_config_file
 
-    user_config_file = os.path.expanduser('~/.beaker_client/config')
+    # ~/.config/beaker-client.conf
+    xdg_config_home = os.environ.get(
+        'XDG_CONFIG_HOME', os.path.expanduser('~/.config')
+    )
+    user_config_file = os.path.join(xdg_config_home, 'beaker-client.conf')
     if os.path.exists(user_config_file):
         return user_config_file
 
+    # ~/.beaker-client/config
+    user_config_file = os.path.expanduser('~/.beaker_client/config')
+    if os.path.exists(user_config_file):
+        sys.stderr.write(
+            '%s is deprecated for config, please use %s instead\n' % (
+                user_config_file,
+                os.path.join(xdg_config_home, 'beaker-client.conf')
+            )
+        )
+        return user_config_file
+
+    # ~/.beaker
     user_config_file = os.path.expanduser('~/.beaker')
     if os.path.exists(user_config_file):
         sys.stderr.write(
             '%s is deprecated for config, please use %s instead\n' % (
-                user_config_file, os.path.expanduser('~/.beaker_client/config')
+                user_config_file,
+                os.path.join(xdg_config_home, 'beaker-client.conf')
             )
         )
         return user_config_file

--- a/Client/src/bkr/client/__init__.py
+++ b/Client/src/bkr/client/__init__.py
@@ -24,6 +24,11 @@ from bkr.common.pyconfig import PyConfigParser
 def get_user_config_file():
     user_config_file = os.environ.get('BEAKER_CLIENT_CONF', None)
     if user_config_file:
+        if not os.path.exists(user_config_file):
+            sys.stderr.write(
+                "File at '%s' indicated by BEAKER_CLIENT_CONF does not exist"
+            )
+            raise SystemExit(1)
         return user_config_file
 
     user_config_file = os.path.expanduser('~/.beaker_client/config')

--- a/Client/src/bkr/client/__init__.py
+++ b/Client/src/bkr/client/__init__.py
@@ -20,22 +20,37 @@ from six.moves.urllib_parse import urljoin
 from bkr.client.command import Command
 from bkr.common.pyconfig import PyConfigParser
 
-user_config_file = os.environ.get("BEAKER_CLIENT_CONF", None)
-if not user_config_file:
-    user_conf = os.path.expanduser('~/.beaker_client/config')
-    old_conf = os.path.expanduser('~/.beaker')
-    if os.path.exists(user_conf):
-        user_config_file = user_conf
-    elif os.path.exists(old_conf):
-        user_config_file = old_conf
-        sys.stderr.write(
-            "%s is deprecated for config, please use %s instead\n" % (old_conf, user_conf))
-    else:
-        pass
 
-system_config_file = None
-if os.path.exists('/etc/beaker/client.conf'):
-    system_config_file = '/etc/beaker/client.conf'
+def get_user_config_file():
+    user_config_file = os.environ.get('BEAKER_CLIENT_CONF', None)
+    if user_config_file:
+        return user_config_file
+
+    user_config_file = os.path.expanduser('~/.beaker_client/config')
+    if os.path.exists(user_config_file):
+        return user_config_file
+
+    user_config_file = os.path.expanduser('~/.beaker')
+    if os.path.exists(user_config_file):
+        sys.stderr.write(
+            '%s is deprecated for config, please use %s instead\n' % (
+                user_config_file, os.path.expanduser('~/.beaker_client/config')
+            )
+        )
+        return user_config_file
+
+    return None
+
+
+def get_system_config_file():
+    if os.path.exists('/etc/beaker/client.conf'):
+        return '/etc/beaker/client.conf'
+
+    return None
+
+
+user_config_file = get_user_config_file()
+system_config_file = get_system_config_file()
 
 conf = PyConfigParser()
 if system_config_file:


### PR DESCRIPTION
It's a standard, and it stop us littering our home directory with yet another config file :)

A small bug is addressed where the path indicated by `BEAKER_CLIENT_CONF` does not exist is also addressed.
