### PR TITLE
Use SPDX license

### DIFF
--- a/beaker.spec
+++ b/beaker.spec
@@ -22,7 +22,7 @@ Version:        29.2
 Release:        1%{?dist}
 Summary:        Full-stack software and hardware integration testing system
 Group:          Applications/Internet
-License:        GPLv2+ and BSD
+License:        GPL-2.0-or-later
 URL:            https://beaker-project.org/
 
 Source0:        https://github.com/beaker-project/beaker/archive/%{name}-%{upstream_version}.tar.gz


### PR DESCRIPTION
The Fedora Project is working to switch all licenses to SPDX format. When they converted our project, they listed the Callaway license for BSD. 

I looked into why this was included and found that Dan C explained it when he added it. The file `LabController/src/bkr/labcontroller/tback.py` was originally from Django and used the 3-clause BSD license, but we have since removed it.

This pull request simply aligns the license with the one we have in Fedora.

The following document may provide additional answers:
https://fedoraproject.org/wiki/Changes/SPDX_Licenses_Phase_1