### PR TITLE
fix: coalesce None env values to empty string

### DIFF
--- a/LabController/src/bkr/labcontroller/provision.py
+++ b/LabController/src/bkr/labcontroller/provision.py
@@ -216,7 +216,7 @@ def build_power_env(command):
     }
 
     for k, v in six.iteritems(power_mapping):
-        env[v] = _decode(command["power"].get(k, ""))
+        env[v] = _decode(command["power"].get(k, "") or "")
 
     env["power_mode"] = _decode(command["action"])
 

--- a/LabController/src/bkr/labcontroller/test_provision.py
+++ b/LabController/src/bkr/labcontroller/test_provision.py
@@ -52,3 +52,25 @@ class TestBuildPowerEnv(unittest.TestCase):
 
         for key, value in six.iteritems(expected):
             self.assertEqual(expected[key], actual[key])
+
+    def test_build_power_env_with_none_values(self):
+        t_command = {
+            "power": {
+                "address": u"/var/run/docker.sock",
+                "id": u"beaker-machine-1",
+                "user": None,
+                "passwd": None,
+            },
+            "action": u"interrupt",
+        }
+
+        actual = build_power_env(t_command)
+
+        self.assertEqual(actual["power_user"], "")
+        self.assertEqual(actual["power_pass"], "")
+        self.assertEqual(actual["power_address"], "/var/run/docker.sock")
+        self.assertEqual(actual["power_id"], "beaker-machine-1")
+        self.assertEqual(actual["power_mode"], "interrupt")
+        for key, value in six.iteritems(actual):
+            self.assertIsInstance(value, str,
+                                 "env[%r] is %r, expected str" % (key, value))


### PR DESCRIPTION
```
2026-02-01 16:55:12,958 bkr.labcontroller.provision DEBUG Launching power script /etc/beaker/power-scripts/docker (attempt 1) with env {'LC_FQDN': 'lc-fedora41', 'HOSTNAME': 'lc-fedora41', 'DISTTAG': 'f41container', 'PWD': '/beaker', 'FBR': 'f41', 'HOME': '/root', 'FGC': 'f41', 'REGISTER_MACHINES': '1', 'PYTHONPATH': '/beaker/Common:/beaker/LabController/src:/beaker/Client/src', 'TERM': 'xterm', 'SHLVL': '0', 'PATH': '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin', '_': '/usr/bin/python3', 'LC_CTYPE': 'C.UTF-8', 'power_address': '/var/run/docker.sock', 'power_id': 'beaker-machine-1', 'power_user': None, 'power_pass': None, 'power_mode': 'interrupt'}
2026-02-01 16:55:12,972 bkr.labcontroller.provision ERROR Error processing command 1
Traceback (most recent call last):
  File "/beaker/LabController/src/bkr/labcontroller/provision.py", line 161, in handle
    handle_power(self.conf, command)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
  File "/beaker/LabController/src/bkr/labcontroller/provision.py", line 275, in handle_power
    p = MonitoredSubprocess([script], env=env,
            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
            timeout=300)
  File "/beaker/LabController/src/bkr/labcontroller/concurrency.py", line 104, in __init__
    super(MonitoredSubprocess, self).__init__(*args, **kwargs)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/site-packages/gevent/subprocess.py", line 819, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        pass_fds, cwd, env, universal_newlines,
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
                        gid, gids, uid, umask,
                        ^^^^^^^^^^^^^^^^^^^^^^
                        start_new_session, process_group)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.13/site-packages/gevent/subprocess.py", line 1849, in _execute_child
    raise child_exception
TypeError: expected str, bytes or os.PathLike object, not NoneType
```