### PR TITLE
Allow importing of distributions in the Python 3 Lab Controller.

### DIFF
--- a/LabController/src/bkr/labcontroller/distro_import.py
+++ b/LabController/src/bkr/labcontroller/distro_import.py
@@ -7,6 +7,7 @@
 import sys, os
 import glob
 import getopt
+import io
 from optparse import OptionParser, OptionGroup
 import logging
 import socket
@@ -155,9 +156,13 @@ class Parser(object):
         self.url = url
         try:
             f = urllib.request.urlopen('%s/%s' % (self.url, self.infofile))
-            self.parser = configparser.ConfigParser()
-            self.parser.readfp(f)
+            data = f.read()
             f.close()
+            if isinstance(data, bytes):
+                data = data.decode('utf-8', errors='replace')
+            self.parser = configparser.ConfigParser()
+            reader = getattr(self.parser, 'read_file', None) or self.parser.readfp
+            reader(io.StringIO(data))
         except urllib.error.URLError:
             return False
         except configparser.MissingSectionHeaderError as e:
@@ -168,8 +173,11 @@ class Parser(object):
         if self.discinfo:
             try:
                 f = urllib.request.urlopen('%s/%s' % (self.url, self.discinfo))
-                self.last_modified = f.read().split("\n")[0]
+                data = f.read()
                 f.close()
+                if isinstance(data, bytes):
+                    data = data.decode('utf-8', errors='replace')
+                self.last_modified = data.split("\n")[0]
             except urllib.error.URLError:
                 pass
         return True
@@ -295,11 +303,11 @@ class ComposeInfoLegacy(ComposeInfoMixin, Importer):
         """
         specific_arches = self.options.arch
         if specific_arches:
-            return filter(lambda x: url_exists(os.path.join(self.parser.url,x)) \
-                      and x, [arch for arch in specific_arches])
+            return list(filter(lambda x: url_exists(os.path.join(self.parser.url,x)) \
+                      and x, [arch for arch in specific_arches]))
         else:
-            return filter(lambda x: url_exists(os.path.join(self.parser.url,x)) \
-                      and x, [arch for arch in self.arches])
+            return list(filter(lambda x: url_exists(os.path.join(self.parser.url,x)) \
+                      and x, [arch for arch in self.arches]))
 
     def get_os_dir(self, arch):
         """ Return path to os directory
@@ -802,8 +810,8 @@ class TreeInfoMixin(object):
         This is just a sanity check, the parser's URL should be the os dir.
         """
         try:
-            os_dir = filter(lambda x: url_exists(x) \
-                            and x, [self.parser.url])[0]
+            os_dir = list(filter(lambda x: url_exists(x) \
+                            and x, [self.parser.url]))[0]
         except IndexError as e:
             raise BX('%s no os_dir found: %s' % (self.parser.url, e))
         return os_dir
@@ -908,7 +916,7 @@ class TreeInfoMixin(object):
             self.tree['osminor'] = '0'
 
         arches = self.parser.get('general', 'arches','')
-        self.tree['arches'] = map(lambda arch: arch.strip(), arches and arches.split(',') or [])
+        self.tree['arches'] = list(map(lambda arch: arch.strip(), arches and arches.split(',') or []))
         full_os_dir = self.get_os_dir()
         # These would have been passed from the Compose*.process()
         common_repos = repos

--- a/LabController/src/bkr/labcontroller/distro_import.py
+++ b/LabController/src/bkr/labcontroller/distro_import.py
@@ -16,8 +16,12 @@ from bkr.common.bexceptions import BX
 import pprint
 import time
 import json
-import dnf
 import uuid
+
+try:
+    import dnf
+except ImportError:
+    dnf = None
 
 from six.moves import configparser
 from six.moves import urllib
@@ -1549,6 +1553,8 @@ class TreeInfoRHVH4(TreeInfoMixin, Importer):
         self.tree["ks_meta"] = "{} {} {}".format(ks_meta, autopart_type, ks_keyword)
 
     def _find_image_update_rpm(self):
+        if dnf is None:
+            raise ImportError('dnf module is required for RHVH imports')
         base = dnf.Base()
         base.repos.add_new_repo(uuid.uuid4().hex, base.conf, baseurl=[self.parser.url])
         base.fill_sack(load_system_repo=False)


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "<string>", line 5, in <module>
    main()
    ~~~~^^
  File "/beaker/LabController/src/bkr/labcontroller/distro_import.py", line 2117, in main
    exit_status.append(build.process(urls, opts))
                       ~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/beaker/LabController/src/bkr/labcontroller/distro_import.py", line 920, in process
    full_os_dir = self.get_os_dir()
  File "/beaker/LabController/src/bkr/labcontroller/distro_import.py", line 813, in get_os_dir
    os_dir = filter(lambda x: url_exists(x) \
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                    and x, [self.parser.url])[0]
                    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^
TypeError: 'filter' object is not subscriptable
```

```
Importing distro from https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/41/Everything/x86_64/os/ ...
Traceback (most recent call last):
  File "<string>", line 5, in <module>
    main()
    ~~~~^^
  File "/beaker/LabController/src/bkr/labcontroller/distro_import.py", line 2100, in main
    build = Build(primary_url, options=opts)
  File "/beaker/LabController/src/bkr/labcontroller/distro_import.py", line 1950, in Build
    parser = cls.is_importer_for(url, options)
  File "/beaker/LabController/src/bkr/labcontroller/distro_import.py", line 1021, in is_importer_for
    if not parser.parse(url):
           ~~~~~~~~~~~~^^^^^
  File "/beaker/LabController/src/bkr/labcontroller/distro_import.py", line 155, in parse
    self.parser.readfp(f)
    ^^^^^^^^^^^^^^^^^^
AttributeError: 'ConfigParser' object has no attribute 'readfp'. Did you mean: 'read'?
```