### PR TITLE
Fix incorrect XPath for guestrecipe in beaker-watchdog

### DIFF
--- a/LabController/src/bkr/labcontroller/watchdog.py
+++ b/LabController/src/bkr/labcontroller/watchdog.py
@@ -91,7 +91,7 @@ class Watchdog(ProxyHelper):
         logger.info('External Watchdog Expired for recipe %s on system %s', recipe_id, system)
         if self.conf.get("WATCHDOG_SCRIPT"):
             job = lxml.etree.fromstring(self.get_my_recipe(dict(recipe_id=recipe_id)))
-            recipe = job.find('recipeSet/guestrecipe')
+            recipe = job.find('recipeSet/recipe/guestrecipe')
             if recipe is None:
                 recipe = job.find('recipeSet/recipe')
             for task in recipe.iterfind('task'):


### PR DESCRIPTION
When an external watchdog expires for a guest recipe in Virtualization workflow, the following error occurs:
```
beaker-watchdog[2548]: bkr.labcontroller.watchdog INFO External Watchdog Expired for recipe 226016 on system virt-guest.localdomain
beaker-watchdog[2548]: bkr.labcontroller.proxy DEBUG get_recipe recipe_id:226016
beaker-server[10091]: bkr.server.xmlrpccontroller DEBUG Handling recipes.to_xml (226016,)
beaker-server[10091]: bkr.server.xmlrpccontroller DEBUG Time: 0:00:00.029563 recipes.to_xml (226016,)
beaker-watchdog[2548]: bkr.labcontroller.watchdog ERROR Failed to abort expired watchdog
beaker-watchdog[2548]:  Traceback (most recent call last):
beaker-watchdog[2548]:    File "/usr/lib/python2.7/site-packages/bkr/labcontroller/watchdog.py", line 141, in poll
beaker-watchdog[2548]:      self.abort(recipe_id, system)
beaker-watchdog[2548]:    File "/usr/lib/python2.7/site-packages/bkr/labcontroller/watchdog.py", line 100, in abort
beaker-watchdog[2548]:      task_id = task.get('id')
beaker-watchdog[2548]:  UnboundLocalError: local variable 'task' referenced before assignment
beaker-watchdog[2548]: bkr.labcontroller.watchdog DEBUG Polling for active watchdogs
beaker-server[25605]: bkr.server.xmlrpccontroller DEBUG Handling recipes.tasks.watchdogs ('active',)
beaker-server[25605]: bkr.server.xmlrpccontroller DEBUG Time: 0:00:00.006841 recipes.tasks.watchdogs 
```

Watchdog.abort() method looks for a guest recipe using XPath 'recipeSet/guestrecipe', but fails because the actual XPath is 'recipeSet/recipe/guestrecipe'.

It then falls back to the parent recipe at 'recipeSet/recipe'. If that recipe has already finished, no running task is found and `task` remains undefined, resulting in an UnboundLocalError.